### PR TITLE
Restore host-driven round flow after merge

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     *{box-sizing:border-box}
     body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,"Helvetica Neue",Arial;background:linear-gradient(180deg,#0d1016,#0f1219 60%,#0b0e14);color:var(--text)}
     .wrap{max-width:1100px;margin:0 auto;padding:20px}
-    header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:10px 0 8px}
+    header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:10px 0 8px;flex-wrap:wrap}
     .logo{font-weight:800;letter-spacing:.3px;font-size:20px;display:flex;align-items:center;gap:10px}
     .logo b{display:inline-block;background:linear-gradient(135deg,var(--accent),#b28dff);-webkit-background-clip:text;background-clip:text;color:transparent}
     .bar{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
@@ -28,7 +28,14 @@
     .chips{display:flex;gap:8px;flex-wrap:wrap}
     .chip{background:var(--chip);border:1px solid var(--border);padding:8px 10px;border-radius:999px;color:#cfd5e6;font-weight:700}
     .card{background:var(--card);border:1px solid var(--border);border-radius:18px;padding:14px}
-    .cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px}
+    .card.black-card{background:#050608;border-color:#1f2536;color:#fff}
+    .card.black-card .muted{color:rgba(255,255,255,.65)}
+    .card.selectable{cursor:pointer;transition:.15s ease}
+    .card.selectable:hover{transform:translateY(-2px);}
+    .card.selected{outline:2px solid var(--accent);box-shadow:0 0 0 3px rgba(124,92,255,.35);transform:translateY(-3px);}
+    .card.disabled{opacity:.55;pointer-events:none}
+    .card.readonly{pointer-events:none}
+    .cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:12px}
     .kicker{display:flex;align-items:center;justify-content:space-between;gap:10px}
     .small{font-size:12px;opacity:.8}
     .big{font-size:20px;line-height:1.35}
@@ -41,9 +48,9 @@
     .toast{position:fixed;left:50%;transform:translateX(-50%);bottom:14px;background:#1c2233;border:1px solid var(--border);padding:10px 12px;border-radius:12px;box-shadow:var(--shadow)}
     @media (max-width: 600px){
       .wrap{max-width:600px;padding:12px}
-      header{flex-wrap:wrap;gap:8px}
+      header{gap:8px}
       .logo{font-size:18px}
-      .bar{gap:6px}
+      .bar{gap:6px;width:100%;justify-content:flex-start}
       button,.btn{padding:12px 14px;border-radius:14px;font-size:16px}
       .panel{padding:12px;border-radius:16px}
       .cards{grid-template-columns: 1fr}
@@ -64,7 +71,6 @@
         <button class="ghost" id="btnHow">Правила</button>
         <button class="ghost" id="btnTests">🧪 Тесты</button>
         <button id="btnNew">Новая игра</button>
-        <button class="ghost hidden" id="btnToJudge">→ Фаза судьи</button>
       </div>
     </header>
 
@@ -99,29 +105,36 @@
           <div>
             <div class="muted small">Комната: <span id="roomIdLabel">—</span></div>
             <div class="muted small">Раунд <span id="roundN">1</span>/<span id="roundTotal">10</span></div>
-            <div style="margin-top:2px;">Судья: <b id="judgeName">—</b></div>
+            <div style="margin-top:2px;">Ведущий: <b id="hostName">—</b></div>
           </div>
-          <div class="chips"><span class="chip" id="turnHint">Фаза: —</span></div>
+          <div class="chips"><span class="chip" id="statusHint">Статус: —</span></div>
         </div>
 
-        <div class="card" style="margin-top:12px;">
+        <div class="card black-card" style="margin-top:12px;">
           <div class="muted small">Чёрная карта</div>
           <div id="blackText" class="big" style="margin-top:6px;">—</div>
         </div>
 
-        <div id="phaseHands" style="margin-top:14px;">
+        <div id="handSection" style="margin-top:14px;">
           <h3>Ваши карты</h3>
-          <div class="muted small">Выберите одну белую карту (ваша рука видна только вам)</div>
+          <div class="muted small" id="selectionHint">Выберите одну белую карту (ваша рука видна только вам)</div>
           <div class="cards" id="handCards" style="margin-top:10px;"></div>
+          <div class="row" id="handActions" style="margin-top:10px;">
+            <button class="ghost" id="btnConfirm" disabled>Подтвердить выбор</button>
+          </div>
+          <div class="card hidden" id="submittedCard" style="margin-top:12px;">
+            <div class="muted small">Вы положили на стол</div>
+            <div class="big" id="submittedCardText" style="margin-top:6px;">—</div>
+          </div>
         </div>
 
-        <div id="phaseJudge" class="hidden" style="margin-top:14px;">
-          <h3>Выбор победителя (судья)</h3>
-          <div class="muted small">Судья <b id="judgeName2">—</b>, выберите лучший ответ:</div>
+        <div id="hostPanel" style="margin-top:14px;">
+          <h3>Ответы на столе</h3>
+          <div class="muted small" id="hostHint">Ждём, пока игроки выберут карты</div>
           <div class="cards" id="submissions" style="margin-top:10px;"></div>
         </div>
 
-        <div id="phaseWinner" class="hidden" style="margin-top:14px;">
+        <div id="resultPanel" class="hidden" style="margin-top:14px;">
           <div class="card winner">
             <div class="muted small">Победитель раунда</div>
             <div class="big" id="winnerLine" style="margin-top:6px;">—</div>
@@ -149,8 +162,8 @@
         <ol class="muted" style="line-height:1.6;">
           <li>Один создаёт комнату и становится ведущим (host).</li>
           <li>Все вводят имя и заходят по ссылке комнаты.</li>
-          <li>Каждый раунд судья меняется по кругу.</li>
-          <li>Игроки выбирают ответы из своей руки, судья выбирает лучший.</li>
+          <li>Ведущий выбирает лучшую карту в каждом раунде.</li>
+          <li>Игроки выбирают ответы из своей руки.</li>
           <li>Победитель получает 1 очко.</li>
         </ol>
         <menu class="row" style="justify-content:flex-end; margin-top:8px;">
@@ -223,7 +236,7 @@
     const MIN_BLACK=120, MIN_WHITE=500;
     const adj=["бескомпромиссный","легендарный","скромный","хрупкий","стальной","мягкий","неудобный","удивительный","космический","тактический","нулевой","случайный","домашний","турбо","антистресс","чистосердечный","ботанский","карманный","праздничный","грустный","героический","виноватый","странный","панический","осознанный","вафельный","экологичный","умный","сверхважный","необъяснимый"];
     const noun=["кактус","ежедневник","кекс","плед","римейк детства","кот в коробке","танец победителя","утренний ритуал","план Б","зум-созвон","марафон сериалов","пакет багов","диванный стартап","апдейт настроения","чай без сахара","стакан воды","неловкая пауза","электронная очередь","перерыв на себя","похвала самому себе","карта желаний","фантазия","чистый стол","новый понедельник","таймер на 5 минут","пища для ума","сон днём","упражнение на растяжку","вдох через нос","молчаливое согласие"];
-    const tails=["в подарок","в 3 часа ночи","по подписке","на скорую руку","в режиме инкогнито","без уведомлений","с доставкой завтра","по любви","на удалёнке","с закрытыми глазами","с одобрения кота","вместо спорта","вдохновляющей формы","без инструкции","с минимальными усилиями","в последнюю секунду","с видом на кухню","в пределах разумного","на полном серьёзе","для галочки","с огоньком","по выходным","для души","под настроение","как-нибудь потом","в хорошем смысле","не для отчёта","по приколу","по старой памяти","без причин"];
+    const tails=["в подарок","в 3 часа ночи","по подписке","на скорую руку","в режиме инкогнито","без уведомлений","с доставкой завтра","по любви","на удалёнке","с закрытыми глазами","с одобрения кота","вместо спорта","в вдохновляющей форме","без инструкции","с минимальными усилиями","в последнюю секунду","с видом на кухню","в пределах разумного","на полном серьёзе","для галочки","с огоньком","по выходным","для души","под настроение","как-нибудь потом","в хорошем смысле","не для отчёта","по приколу","по старой памяти","без причин"];
     function genWhite(i){ return `${adj[i%adj.length]} ${noun[(i*7)%noun.length]} ${tails[(i*13)%tails.length]}`; }
     const blackStarts=["Мой день начинается с ____.","На совещании лучше не обсуждать ____.","Секрет успешного проекта — ____.","Сегодняшний план: кофе, дела и ____.","Самый странный подарок — ____.","Я бы с радостью заменил(а) гимн на ____.","Когда никто не видит, я практикую ____.","Лучшее, что можно добавить в резюме — ____.","Идеальное алиби: ____.","Главный антистресс — ____.","Спорим, в 2035 мы будем платить за ____.","В корпоративном чате забанили тему ____.","Главная фича нового айфона — ____.","Если бы у меня был слоган, он бы был про ____.","На TED я выступлю про ____.","Мой внутренний критик обожает ____.","Шеф мечтает внедрить ____.","User story на сегодня — ____.","Я официально отказываюсь от ____.","Сегодня отменяется всё, кроме ____."];
     const needW=Math.max(0, MIN_WHITE-(base.white?.length||0)); for(let i=0;i<needW;i++) base.white.push(genWhite(i));
@@ -275,11 +288,12 @@
 
   // ===== ЛОГИКА КОМНАТЫ / СОСТОЯНИЕ =====
   const STORAGE_KEY = 'zlobnye_karty_deck_v1';
-  const local = { playerId: localStorage.getItem('playerId') || uid(), name:'', roomId:null, isHost:false };
+  const local = { playerId: localStorage.getItem('playerId') || uid(), name:'', roomId:null, isHost:false, hostId:null, currentRound:0, hasSubmitted:false, selectedCardIndex:null, selectedCardText:'', submittedCardText:'' };
   localStorage.setItem('playerId', local.playerId);
 
-  const game = { state: { round:0, roundsTotal:10, judgeIndex:0, phase:'lobby', blackCard:'', sfwOnly:true },
-                 deck: { black:[], white:[], discardBlack:[], discardWhite:[] } };
+  const game = { state: { round:0, roundsTotal:10, status:'lobby', blackCard:'', sfwOnly:true, hostName:'', hostId:null },
+                 deck: { black:[], white:[], discardBlack:[], discardWhite:[] },
+                 submissions: {}, submissionsOrder: [] };
 
   function fillBlack(black, white){
     return black.includes('____') ? black.replace('____', `<b>${escapeHtml(white)}</b>`) : `${black} — <b>${escapeHtml(white)}</b>`;
@@ -291,14 +305,26 @@
 
   // ===== Работа с колодой (на стороне ведущего) =====
   function loadDeckLocal(){
-    const raw = localStorage.getItem(STORAGE_KEY); let base = DEMO_DECK; if (raw){ try{ base = JSON.parse(raw);}catch(e){ console.warn('Bad deck JSON'); } }
+    const raw = localStorage.getItem(STORAGE_KEY);
+    let base;
+    if (raw){
+      try{ base = JSON.parse(raw); }
+      catch(e){ console.warn('Bad deck JSON, fallback to demo'); base = JSON.parse(JSON.stringify(DEMO_DECK)); }
+    } else {
+      base = JSON.parse(JSON.stringify(DEMO_DECK));
+    }
     ensureMinimumDeck(base);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(base));
     const black=[...base.black], white=[...base.white];
-    game.deck.black = shuffle(black); game.deck.white = shuffle(white);
-    $('#deckJson').value = JSON.stringify(base, null, 2);
+    game.deck.black = shuffle(black);
+    game.deck.white = shuffle(white);
+    game.deck.discardBlack = [];
+    game.deck.discardWhite = [];
+    const textarea = $('#deckJson');
+    if (textarea){ textarea.value = JSON.stringify(base, null, 2); }
   }
-  function drawBlack(){ if(!game.deck.black.length){ game.deck.black = shuffle(game.deck.discardBlack); game.deck.discardBlack = []; } return game.deck.black.pop() || '— пусто —'; }
-  function drawWhite(){ if(!game.deck.white.length){ game.deck.white = shuffle(game.deck.discardWhite); game.deck.discardWhite = []; } return game.deck.white.pop() || '— пусто —'; }
+  function drawBlack(){ if(!game.deck.black.length){ game.deck.black = shuffle(game.deck.discardBlack); game.deck.discardBlack = []; } const card = game.deck.black.pop() || '— пусто —'; return card; }
+  function drawWhite(){ if(!game.deck.white.length){ game.deck.white = shuffle(game.deck.discardWhite); game.deck.discardWhite = []; } const card = game.deck.white.pop() || '— пусто —'; return card; }
 
   // ===== Firebase helpers =====
   const roomRef = ()=> db.ref(`rooms/${local.roomId}`);
@@ -310,8 +336,10 @@
   // Хелпер: синхронизируем роль хоста при любых перезаходах
   function watchHost(){
     roomRef().child('hostId').on('value', snap => {
+      const hostId = snap.val();
+      local.hostId = hostId;
       const was = local.isHost;
-      local.isHost = (snap.val() === local.playerId);
+      local.isHost = (hostId === local.playerId);
       if (local.isHost !== was) renderState();
     });
   }
@@ -324,7 +352,7 @@
     loadDeckLocal();
     try{
       await roomRef().set({ hostId: local.playerId, createdAt: Date.now() });
-      await stateRef().set({ ...game.state, phase:'lobby', sfwOnly: $('#sfwOnly').checked });
+      await stateRef().set({ ...game.state, status:'lobby', sfwOnly: $('#sfwOnly').checked });
       await db.ref(`rooms/${local.roomId}/deck`).set({ black: game.deck.black, white: game.deck.white });
       updateShareLink();
       subscribeRoom();
@@ -362,7 +390,7 @@
     if (!local.name) { local.name = 'Игрок ' + local.playerId.slice(-4); }
     localStorage.setItem('playerName', local.name);
     const pRef = playersRef().child(local.playerId);
-    await pRef.set({ name: local.name, score:0, isJudge:false, joinedAt: Date.now() });
+    await pRef.set({ name: local.name, score:0, joinedAt: Date.now() });
     await pRef.onDisconnect().remove();
     // выдать руку (ведущий)
     if (local.isHost){
@@ -388,22 +416,42 @@
   }
 
   // ===== ЛОББИ/ИГРА ПЕРЕКЛЮЧЕНИЕ =====
+  function resetPlayerRoundState(round){
+    local.currentRound = round || 0;
+    local.hasSubmitted = false;
+    local.selectedCardIndex = null;
+    local.selectedCardText = '';
+    local.submittedCardText = '';
+  }
+
   function renderState(){
     const s = game.state || {};
-    if (s.phase==='lobby'){ $('#screenLobby').classList.remove('hidden'); $('#screenGame').classList.add('hidden'); }
+    const status = s.status || 'lobby';
+    if (status==='lobby'){ $('#screenLobby').classList.remove('hidden'); $('#screenGame').classList.add('hidden'); }
     else { $('#screenLobby').classList.add('hidden'); $('#screenGame').classList.remove('hidden'); }
+    if (status==='lobby'){ resetPlayerRoundState(0); }
+    if (status==='collect' && (s.round||0) !== local.currentRound){
+      resetPlayerRoundState(s.round||0);
+    }
     $('#roomIdLabel').textContent = local.roomId || '—';
     $('#roundN').textContent = s.round || 0; $('#roundTotal').textContent = s.roundsTotal || 10;
-    $('#judgeName').textContent = s.judgeName || '—'; $('#judgeName2').textContent = s.judgeName || '—';
+    $('#hostName').textContent = s.hostName || '—';
     $('#blackText').innerHTML = escapeHtml(s.blackCard || '—');
-    $('#turnHint').textContent = 'Фаза: ' + (s.phase||'—');
-    // Фазы видимости
-    $('#phaseHands').classList.toggle('hidden', s.phase!=='hands');
-    $('#phaseJudge').classList.toggle('hidden', s.phase!=='judge');
-    $('#phaseWinner').classList.toggle('hidden', s.phase!=='winner');
-    // Кнопки ведущего
-    const showToJudge = local.isHost && s.phase==='hands';
-    $('#btnToJudge')?.classList.toggle('hidden', !showToJudge);
+    const statusMap = { lobby:'ожидание игроков', collect:'сбор ответов', result:'результат раунда' };
+    $('#statusHint').textContent = 'Статус: ' + (statusMap[status] || '—');
+    $('#handSection').classList.toggle('hidden', status==='lobby');
+    $('#hostPanel').classList.toggle('hidden', status==='lobby');
+    const isResult = status==='result';
+    $('#resultPanel').classList.toggle('hidden', !isResult);
+    if (isResult){
+      const winnerName = s.lastWinnerName || '—';
+      const answer = s.lastAnswer || '';
+      $('#winnerLine').innerHTML = `${escapeHtml(winnerName)} получает очко за: ${fillBlack(s.blackCard||'', answer)}`;
+    }
+    updateSelectionUI();
+    updateHostHint();
+    renderSubmissions(game.submissions);
+    $('#nextRound').classList.toggle('hidden', !local.isHost);
   }
 
   function renderPlayers(players){
@@ -411,7 +459,8 @@
     const arr=Object.entries(players).map(([id,p])=>({id,...p})).sort((a,b)=> (b.score||0)-(a.score||0));
     arr.forEach(p=>{
       const row=document.createElement('div'); row.className='kicker'; row.style.padding='6px 0';
-      row.innerHTML=`<div>${escapeHtml(p.name)} ${p.isJudge?'<span class="small muted">(судья)</span>':''}</div><div class="chip">${p.score||0}</div>`;
+      const isHost = p.id === (local.hostId || game.state.hostId);
+      row.innerHTML=`<div>${escapeHtml(p.name)} ${isHost?'<span class="small muted">(ведущий)</span>':''}</div><div class="chip">${p.score||0}</div>`;
       box.appendChild(row);
     });
   }
@@ -425,48 +474,189 @@
     });
   }
 
-  async function setJudgeFlags(ids, judgeId){
-    if (!ids.length) return;
-    const updates={};
-    ids.forEach(pid=>{ updates[`${pid}/isJudge`] = pid === judgeId; });
-    await playersRef().update(updates);
-  }
-
   function renderHand(hand){
     const box=$('#handCards'); box.innerHTML='';
+    const disabled = local.hasSubmitted || (game.state.status!=='collect');
     hand.forEach((txt,i)=>{
-      const btn=document.createElement('button'); btn.className='card'; btn.style.textAlign='left'; btn.textContent=txt;
-      btn.onclick=()=> submitCard(txt, i);
+      const btn=document.createElement('button'); btn.className='card'; btn.dataset.index=i; btn.style.textAlign='left';
+      btn.innerHTML = `<div class="big">${escapeHtml(txt)}</div>`;
+      if (disabled){
+        btn.disabled = true;
+        btn.classList.add('disabled');
+      } else {
+        btn.disabled = false;
+        btn.classList.add('selectable');
+        btn.onclick=()=> selectCard(i, txt);
+      }
       box.appendChild(btn);
+    });
+    if (disabled){
+      local.selectedCardIndex = null;
+      local.selectedCardText = '';
+    } else if (local.selectedCardIndex !== null && local.selectedCardIndex >= hand.length){
+      local.selectedCardIndex = null;
+      local.selectedCardText = '';
+    }
+    refreshHandSelectionStyles();
+    updateSelectionUI();
+  }
+
+  function selectCard(idx, text){
+    if (local.hasSubmitted) return;
+    if ((game.state.status||'')!=='collect') return;
+    local.selectedCardIndex = idx;
+    local.selectedCardText = text;
+    refreshHandSelectionStyles();
+    updateSelectionUI();
+  }
+
+  function refreshHandSelectionStyles(){
+    const status = game.state.status || 'lobby';
+    const canPick = status==='collect' && !local.hasSubmitted;
+    $$('#handCards .card').forEach(el=>{
+      const idx = Number(el.dataset.index);
+      const isSelected = idx === local.selectedCardIndex && canPick;
+      el.classList.toggle('selected', isSelected);
+      el.classList.toggle('disabled', !canPick);
+      if (canPick){
+        el.classList.add('selectable');
+        if (el instanceof HTMLButtonElement) el.disabled = false;
+      } else {
+        el.classList.remove('selectable');
+        if (el instanceof HTMLButtonElement) el.disabled = true;
+      }
     });
   }
 
-  async function submitCard(text, idx){
-    const s= (await stateRef().get()).val(); if (!s || s.phase!=='hands') { toast('Ждём фазу выбора'); return; }
-    // убрать карту из руки
-    const handSnap = await perPlayerRef(local.playerId).get(); let hand=(handSnap.val()&&handSnap.val().hand)||[]; hand.splice(idx,1);
+  function updateSelectionUI(){
+    const hint = $('#selectionHint');
+    const btn = $('#btnConfirm');
+    const submittedBox = $('#submittedCard');
+    const status = game.state.status || 'lobby';
+    if (hint){
+      if (status==='collect'){
+        if (local.hasSubmitted){
+          hint.textContent = 'Выбор сделан, ждём ведущего.';
+        } else if (local.selectedCardIndex === null){
+          hint.textContent = 'Выберите одну белую карту (ваша рука видна только вам).';
+        } else {
+          hint.textContent = 'Нажмите «Подтвердить выбор», чтобы отправить карту.';
+        }
+      } else if (status==='result'){
+        hint.textContent = 'Раунд завершён, ожидаем следующую раздачу.';
+      } else {
+        hint.textContent = 'Ожидаем начало раунда.';
+      }
+    }
+    if (btn){
+      const canConfirm = !local.hasSubmitted && status==='collect' && local.selectedCardIndex !== null;
+      btn.disabled = !canConfirm;
+      btn.classList.toggle('hidden', status!=='collect' || local.hasSubmitted);
+    }
+    if (submittedBox){
+      submittedBox.classList.toggle('hidden', !local.hasSubmitted);
+      if (local.hasSubmitted){
+        $('#submittedCardText').textContent = local.submittedCardText || '—';
+      }
+    }
+  }
+
+  async function submitCard(text){
+    const status = (game.state && game.state.status) || 'lobby';
+    if (status!=='collect'){ toast('Сейчас нельзя отправить карту'); return; }
+    const handSnap = await perPlayerRef(local.playerId).get();
+    let hand=(handSnap.val()&&handSnap.val().hand)||[];
+    let idx = local.selectedCardIndex;
+    if (idx==null || hand[idx] !== text){ idx = hand.indexOf(text); }
+    if (idx<0){ toast('Карта уже разыграна'); return; }
+    hand.splice(idx,1);
     await perPlayerRef(local.playerId).set({ hand });
-    // добавить в submissions
     const id = uid(); await submissionsRef().child(id).set({ playerId: local.playerId, text, t:Date.now() });
+    local.hasSubmitted = true;
+    local.submittedCardText = text;
+    local.selectedCardIndex = null;
+    local.selectedCardText = '';
+    refreshHandSelectionStyles();
+    updateSelectionUI();
+    updateHostHint();
     toast('Ответ отправлен');
   }
 
+  function updateHostHint(){
+    const hostHint = $('#hostHint');
+    if (!hostHint) return;
+    const status = game.state.status || 'lobby';
+    const submissionsCount = Object.keys(game.submissions||{}).length;
+    if (status==='lobby'){
+      hostHint.textContent = 'Ждём игроков.';
+      return;
+    }
+    if (status==='collect'){
+      if (local.isHost){
+        hostHint.textContent = submissionsCount ? 'Можно выбрать лучший ответ.' : 'Ждём, пока игроки выберут карты.';
+      } else {
+        hostHint.textContent = local.hasSubmitted ? 'Ждём остальных игроков и решение ведущего.' : 'Сделайте выбор и подтвердите карту.';
+      }
+    } else if (status==='result'){
+      hostHint.textContent = local.isHost ? 'Нажмите «Следующий раунд», чтобы продолжить.' : 'Ведущий решает, когда перейти к следующему раунду.';
+    } else {
+      hostHint.textContent = 'Ждём ведущего.';
+    }
+  }
+
   function renderSubmissions(map){
+    game.submissions = map || {};
     const box=$('#submissions'); box.innerHTML='';
-    const items = shuffle(Object.entries(map||{}).map(([id,s])=>({id,...s})));
+    const entries = Object.entries(game.submissions);
+    if (!entries.length){
+      game.submissionsOrder = [];
+      const empty=document.createElement('div'); empty.className='muted small'; empty.textContent='Пока нет сыгранных карт.';
+      box.appendChild(empty);
+      updateHostHint();
+      return;
+    }
+    const keys = entries.map(([id])=>id);
+    const orderCurrent = Array.isArray(game.submissionsOrder) ? game.submissionsOrder.filter(id=>game.submissions[id]) : [];
+    let order = orderCurrent;
+    const sameSize = order.length === keys.length;
+    const sameSet = sameSize && order.every(id=> game.submissions[id]);
+    if (!sameSet){
+      order = shuffle([...keys]);
+      game.submissionsOrder = order.slice();
+    }
+    const items = order.map(id=>({ id, ...(game.submissions[id]||{}) })).filter(s=> typeof s.text === 'string');
+    if (!items.length){
+      const empty=document.createElement('div'); empty.className='muted small'; empty.textContent='Пока нет сыгранных карт.';
+      box.appendChild(empty);
+      updateHostHint();
+      return;
+    }
+    const reveal = local.isHost || (game.state.status==='result');
+    if (!reveal){
+      const wait=document.createElement('div'); wait.className='muted small'; wait.textContent='Ответы скрыты до выбора ведущего.';
+      box.appendChild(wait);
+      updateHostHint();
+      return;
+    }
     items.forEach(s=>{
       const b=document.createElement('button'); b.className='card'; b.style.textAlign='left';
       b.innerHTML=`<div class="muted small">Ответ</div><div class="big">${fillBlack(game.state.blackCard||'', s.text)}</div>`;
-      b.onclick=()=> local.isHost && game.state.phase==='judge' ? pickWinner(s.playerId, s.text) : null;
+      if (local.isHost && game.state.status==='collect'){
+        b.onclick=()=> pickWinner(s.playerId, s.text);
+      } else {
+        b.classList.add('readonly');
+        b.setAttribute('tabindex','-1');
+      }
       box.appendChild(b);
     });
+    updateHostHint();
   }
 
   // ===== Ведущий: старт/раунды/победитель =====
   function maybeAutoStart(players){
     try{
       if (!local.isHost) return;
-      if ((game.state && game.state.phase)!=='lobby') return;
+      if ((game.state && game.state.status)!=='lobby') return;
       const count = Object.keys(players||{}).length;
       if (count >= 2) { startGameHost(); }
     } catch(e){ console.warn('autoStart skipped', e); }
@@ -475,40 +665,46 @@
   async function startGameHost(){
     if (!local.isHost) return toast('Только ведущий может стартовать');
     if (playersCount < 2) return toast('Нужно минимум 2 игрока');
-    // подготовка: назначить судью 0, выдать карты всем, чёрную карту
-    game.state.round=1; game.state.phase='hands'; game.state.roundsTotal=10; game.state.judgeIndex=0;
+    game.state.round=1; game.state.status='collect'; game.state.roundsTotal=10;
     const playersSnap = await playersRef().get(); const players = playersSnap.val()||{}; const ids = orderedPlayerIds(players);
-    // руки уже выданы при регистрации; убедимся, что у всех по 7
     for(const pid of ids){ const handSnap = await perPlayerRef(pid).get(); let hand=(handSnap.val()&&handSnap.val().hand)||[]; while(hand.length<7) hand.push(drawWhite()); await perPlayerRef(pid).set({ hand }); }
-    const judgeId = ids[0] || null; const judgeName = judgeId ? players[judgeId].name : '—';
+    const hostId = local.playerId;
+    const hostName = players[hostId]?.name || local.name || '—';
     const black = drawBlack();
-    await stateRef().set({ ...game.state, judgeId, judgeName, blackCard:black, sfwOnly: $('#sfwOnly').checked });
-    await setJudgeFlags(ids, judgeId);
+    await stateRef().set({ round:1, roundsTotal:game.state.roundsTotal, status:'collect', hostId, hostName, blackCard:black, lastWinnerName:'', lastAnswer:'', sfwOnly: $('#sfwOnly').checked });
     await submissionsRef().remove();
+    game.submissions = {};
+    game.submissionsOrder = [];
+    renderSubmissions(game.submissions);
     await db.ref(`rooms/${local.roomId}/deck`).set({ black: game.deck.black, white: game.deck.white, discardBlack: game.deck.discardBlack, discardWhite: game.deck.discardWhite });
+    resetPlayerRoundState(1);
+    updateSelectionUI();
   }
-
-  async function toJudgePhaseHost(){ if(!local.isHost) return; await stateRef().update({ phase:'judge' }); }
 
   async function pickWinner(playerId, answer){
     if (!local.isHost) return;
-    // +1 очко игроку
     const pRef = playersRef().child(playerId); const pSnap = await pRef.get(); const p=pSnap.val()||{}; await pRef.update({ score:(p.score||0)+1 });
-    await stateRef().update({ phase:'winner', lastWinnerName: p.name, lastAnswer: answer });
-    $('#winnerLine').innerHTML = `${escapeHtml(p.name||'—')} получает очко за: ${fillBlack(game.state.blackCard||'', answer)}`;
+    Object.values(game.submissions).forEach(s=>{ if (s && typeof s.text==='string') game.deck.discardWhite.push(s.text); });
+    await db.ref(`rooms/${local.roomId}/deck`).update({ discardWhite: game.deck.discardWhite });
+    await stateRef().update({ status:'result', lastWinnerName: p.name, lastAnswer: answer });
+    toast(`Победитель: ${p.name||'—'}`);
   }
 
   async function nextRoundHost(){
     if (!local.isHost) return; const sSnap = await stateRef().get(); const s = sSnap.val(); if (!s) return;
     if (s.round >= s.roundsTotal) { toast('Игра окончена'); return; }
     const players = (await playersRef().get()).val()||{}; const ids = orderedPlayerIds(players);
-    const judgeIdx = (ids.indexOf(s.judgeId)+1) % ids.length; const judgeId = ids[judgeIdx]; const judgeName = players[judgeId].name;
-    // новая чёрная, очистить submissions, добрать по 1 карте всем
     for(const pid of ids){ const handSnap = await perPlayerRef(pid).get(); let hand=(handSnap.val()&&handSnap.val().hand)||[]; while(hand.length<7) hand.push(drawWhite()); await perPlayerRef(pid).set({ hand }); }
     await submissionsRef().remove();
+    game.submissions = {};
+    game.submissionsOrder = [];
+    renderSubmissions(game.submissions);
+    if (s.blackCard) game.deck.discardBlack.push(s.blackCard);
     const black = drawBlack();
-    await stateRef().set({ ...s, round: s.round+1, judgeId, judgeName, blackCard:black, phase:'hands' });
-    await setJudgeFlags(ids, judgeId);
+    await stateRef().set({ ...s, round: s.round+1, status:'collect', blackCard:black, lastWinnerName:'', lastAnswer:'' });
+    await db.ref(`rooms/${local.roomId}/deck`).set({ black: game.deck.black, white: game.deck.white, discardBlack: game.deck.discardBlack, discardWhite: game.deck.discardWhite });
+    resetPlayerRoundState((s.round||0)+1);
+    updateSelectionUI();
   }
 
   // ===== Тесты (локальные для чистых функций) =====
@@ -525,7 +721,7 @@
   test('escapeHtml() double quote',()=>{ const s=escapeHtml('"'); expect(s==='&quot;','not &quot;'); });
   test('escapeHtml() complex',()=>{ const s=escapeHtml('<tag> & "\'"'); expect(s.includes('&lt;tag&gt;') && s.includes('&amp;') && s.includes('&quot;') && s.includes('&#39;'),'escape failed'); });
   test('ensureMinimumDeck() idempotent-ish',()=>{ const base={black:["Q"],white:["W"]}; ensureMinimumDeck(base); const b1=base.black.length,w1=base.white.length; ensureMinimumDeck(base); expect(base.black.length>=b1 && base.white.length>=w1,'not growing to min'); });
-  
+
   // ===== Обработчики =====
   $('#btnHow').onclick=()=> $('#dlgRules').showModal();
   $('#btnDeck').onclick=()=> $('#dlgDeck').showModal();
@@ -538,7 +734,7 @@
   $('#btnCreate').onclick=async()=>{ await createRoom(); };
   $('#btnJoin').onclick=async()=>{ const id=($('#roomInput').value||'').trim(); if(!id) return toast('Введите ID комнаты'); await joinRoom(id); };
   $('#btnCopy').onclick=()=>{ navigator.clipboard.writeText($('#shareLink').value); toast('Ссылка скопирована'); };
-  $('#btnToJudge').onclick = toJudgePhaseHost;
+  $('#btnConfirm').onclick=()=>{ if (local.hasSubmitted) return; if (!local.selectedCardText){ toast('Сначала выберите карту'); return; } submitCard(local.selectedCardText); };
   $('#nextRound').onclick=nextRoundHost;
 
   function updateShareLink(){


### PR DESCRIPTION
## Summary
- restore the host-led lobby/game flow with status-based panels and submission controls
- reintroduce player hand selection management, submission confirmation, and host hints
- keep the deck editor and local utilities while syncing deck/discard state during rounds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de28e11e08832684218c7129055d98