### PR TITLE
Trigger auto-start after playersOrder updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,564 +3,1024 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>500 злобных карт — мультиплеер (один HTML)</title>
+  <title>500 злобных карт — мультиплеер</title>
   <style>
-    :root { --bg:#0f1115; --panel:#151823; --muted:#8b93a7; --text:#e6e9f2; --accent:#7c5cff; --accent-2:#25d0a2; --danger:#ff5c7c; --card:#1b2030; --chip:#20263a; --border:#2a3248; --shadow:0 10px 30px rgba(0,0,0,.35);} 
+    :root {
+      --bg:#0d1016;
+      --panel:#171b27;
+      --panel-soft:rgba(23,27,39,0.86);
+      --muted:#8b93a7;
+      --text:#f1f3fb;
+      --accent:#7c5cff;
+      --accent-2:#25d0a2;
+      --danger:#ff5c7c;
+      --chip:#20263a;
+      --border:#2a3248;
+      --card:#1b2030;
+      --shadow:0 16px 44px rgba(0,0,0,.45);
+      --focus-ring:0 0 0 3px rgba(124,92,255,.35);
+      --safe-bottom:env(safe-area-inset-bottom, 0px);
+    }
     *{box-sizing:border-box}
-    body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,"Helvetica Neue",Arial;background:linear-gradient(180deg,#0d1016,#0f1219 60%,#0b0e14);color:var(--text)}
-    .wrap{max-width:1100px;margin:0 auto;padding:20px}
-    header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:10px 0 8px}
-    .logo{font-weight:800;letter-spacing:.3px;font-size:20px;display:flex;align-items:center;gap:10px}
-    .logo b{display:inline-block;background:linear-gradient(135deg,var(--accent),#b28dff);-webkit-background-clip:text;background-clip:text;color:transparent}
-    .bar{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
-    button,.btn{background:var(--accent);color:#fff;border:none;padding:10px 14px;border-radius:12px;cursor:pointer;font-weight:700;box-shadow:var(--shadow);transition:.15s ease}
-    button.ghost,.btn.ghost{background:transparent;border:1px solid var(--border);color:var(--text);box-shadow:none}
-    button.texty{background:transparent;border:none;color:var(--muted);padding:8px 10px}
-    button:hover{transform:translateY(-1px);filter:saturate(1.1)}
-    .grid{display:grid;grid-template-columns:repeat(12,1fr);gap:16px}
-    .panel{grid-column:span 12;background:var(--panel);border:1px solid var(--border);border-radius:20px;padding:16px;box-shadow:var(--shadow)}
-    @media(min-width:900px){.panel.split{grid-column:span 8}.panel.side{grid-column:span 4;position:sticky;top:12px;align-self:start}}
-    h2{margin:8px 0 10px;font-size:18px}
-    h3{margin:8px 0;font-size:16px;color:var(--muted);font-weight:700}
-    .muted{color:var(--muted)}
-    .row{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
-    input[type="text"],input[type="number"],textarea{width:100%;background:var(--chip);border:1px solid var(--border);color:var(--text);padding:10px 12px;border-radius:12px;outline:none}
-    .chips{display:flex;gap:8px;flex-wrap:wrap}
-    .chip{background:var(--chip);border:1px solid var(--border);padding:8px 10px;border-radius:999px;color:#cfd5e6;font-weight:700}
-    .card{background:var(--card);border:1px solid var(--border);border-radius:18px;padding:14px}
-    .cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px}
-    .kicker{display:flex;align-items:center;justify-content:space-between;gap:10px}
-    .small{font-size:12px;opacity:.8}
-    .big{font-size:20px;line-height:1.35}
-    .winner{background:linear-gradient(135deg,rgba(37,208,162,.15),rgba(124,92,255,.15));border-color:#39456b}
-    .scroll{max-height:260px;overflow:auto;padding-right:6px}
-    .hr{height:1px;background:var(--border);margin:12px 0}
-    .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace}
-    .hidden{display:none!important}
-    .link{color:#b7c1ff;text-decoration:underline;cursor:pointer}
-    .toast{position:fixed;left:50%;transform:translateX(-50%);bottom:14px;background:#1c2233;border:1px solid var(--border);padding:10px 12px;border-radius:12px;box-shadow:var(--shadow)}
-    @media (max-width: 600px){
-      .wrap{max-width:600px;padding:12px}
-      header{flex-wrap:wrap;gap:8px}
-      .logo{font-size:18px}
-      .bar{gap:6px}
-      button,.btn{padding:12px 14px;border-radius:14px;font-size:16px}
-      .panel{padding:12px;border-radius:16px}
-      .cards{grid-template-columns: 1fr}
-      .card{padding:16px;font-size:18px}
-      .big{font-size:18px}
-      #playersList .kicker{padding:10px 0}
+    body{
+      margin:0;
+      font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,Ubuntu,Cantarell,"Noto Sans","Helvetica Neue",Arial;
+      min-height:100vh;
+      background:radial-gradient(circle at 20% -10%,rgba(124,92,255,.25),transparent 55%),
+                 radial-gradient(circle at 80% -10%,rgba(37,208,162,.18),transparent 60%),
+                 var(--bg);
+      color:var(--text);
+    }
+    a{color:inherit}
+    button{
+      border:none;
+      font:inherit;
+      cursor:pointer;
+      transition:transform .16s ease, filter .18s ease, box-shadow .2s ease;
+    }
+    button:disabled{opacity:.55;cursor:not-allowed;box-shadow:none;transform:none;filter:none}
+    button:focus-visible{outline:none;box-shadow:var(--focus-ring);}
+    .ghost{background:transparent;border:1px solid var(--border);color:var(--text);box-shadow:none}
+    .primary{
+      background:var(--accent);
+      color:#fff;
+      padding:13px 18px;
+      border-radius:16px;
+      font-weight:700;
+      box-shadow:var(--shadow);
+    }
+    .ghost-rounded{padding:12px 16px;border-radius:16px;font-weight:600;}
+    .icon-btn{
+      background:var(--panel-soft);
+      color:var(--text);
+      border:1px solid rgba(255,255,255,.08);
+      width:44px;height:44px;
+      border-radius:14px;
+      display:flex;align-items:center;justify-content:center;
+      font-size:21px;
+      box-shadow:var(--shadow);
+    }
+    .icon-btn:hover:not(:disabled), .primary:hover:not(:disabled), .ghost-rounded:hover:not(:disabled){transform:translateY(-1px);filter:saturate(1.05);}
+    header{
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      padding:18px 20px 12px;
+      position:sticky;
+      top:0;
+      z-index:30;
+      background:linear-gradient(180deg,rgba(13,16,22,.95),rgba(13,16,22,.65) 60%,transparent);
+      backdrop-filter:blur(12px);
+    }
+    .logo{display:flex;align-items:center;gap:12px;font-weight:800;font-size:20px;letter-spacing:.2px;}
+    .logo b{background:linear-gradient(135deg,var(--accent),#b28dff);-webkit-background-clip:text;background-clip:text;color:transparent;}
+    .wrap{max-width:900px;margin:0 auto;padding:0 16px 140px;}
+    main{display:none;margin-top:24px;}
+    main.active{display:block;}
+    .card{
+      background:var(--panel);
+      border:1px solid var(--border);
+      border-radius:22px;
+      padding:22px;
+      box-shadow:var(--shadow);
+      backdrop-filter:blur(10px);
+    }
+    h1{margin:0 0 16px;font-size:26px;}
+    h2{margin:0 0 14px;font-size:20px;}
+    p{margin:0 0 14px;line-height:1.6;}
+    .muted{color:var(--muted);}
+    .small{font-size:13px;opacity:.85;}
+    label{display:flex;flex-direction:column;gap:8px;font-weight:600;}
+    input[type="text"], textarea{
+      width:100%;
+      padding:13px 16px;
+      border-radius:16px;
+      border:1px solid var(--border);
+      background:rgba(32,38,58,.65);
+      color:var(--text);
+      font-size:16px;
+      transition:border .2s ease, box-shadow .2s ease;
+    }
+    input[type="text"]:focus, textarea:focus{border-color:var(--accent);box-shadow:var(--focus-ring);outline:none;}
+    .field-gap{display:flex;flex-direction:column;gap:16px;margin-bottom:18px;}
+    .actions-row{display:flex;flex-direction:column;gap:12px;margin-top:10px;}
+    .chip{
+      display:inline-flex;align-items:center;gap:6px;
+      background:var(--chip);
+      border:1px solid var(--border);
+      color:#d2d9ef;
+      padding:8px 12px;
+      border-radius:999px;
+      font-size:13px;
+      font-weight:600;
+    }
+    .chip.danger{color:#ffc0d6;border-color:rgba(255,92,124,.45);}
+    .status-board{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin-bottom:18px;}
+    .black-card{
+      background:#050608;
+      border:1px solid #1f2536;
+      color:#fff;
+      border-radius:22px;
+      padding:22px;
+      margin-bottom:20px;
+      box-shadow:0 18px 48px rgba(0,0,0,.45);
+    }
+    .black-card .muted{color:rgba(255,255,255,.7);font-size:13px;}
+    .cards-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(210px,1fr));gap:14px;}
+    .answer-card{
+      background:var(--card);
+      border:1px solid var(--border);
+      border-radius:20px;
+      padding:18px;
+      text-align:left;
+      line-height:1.5;
+      transition:transform .2s ease, box-shadow .2s ease;
+    }
+    .answer-card.selectable{cursor:pointer;}
+    .answer-card.selectable:hover{transform:translateY(-2px);box-shadow:0 18px 40px rgba(0,0,0,.4);}
+    .answer-card.selected{outline:2px solid var(--accent);box-shadow:0 0 0 3px rgba(124,92,255,.35),0 18px 40px rgba(0,0,0,.45);transform:translateY(-3px);}
+    .answer-card.disabled{opacity:.55;pointer-events:none;}
+    .scroll{max-height:320px;overflow:auto;padding-right:6px;}
+    .scroll::-webkit-scrollbar{width:6px;}
+    .scroll::-webkit-scrollbar-thumb{background:rgba(255,255,255,.12);border-radius:999px;}
+    table.scoreboard{width:100%;border-collapse:separate;border-spacing:0 8px;}
+    table.scoreboard td{padding:8px 0;}
+    .toast{
+      position:fixed;
+      left:50%;
+      bottom:calc(20px + var(--safe-bottom));
+      transform:translate(-50%, 60px);
+      padding:14px 18px;
+      background:var(--panel-soft);
+      border:1px solid rgba(255,255,255,.08);
+      border-radius:16px;
+      box-shadow:var(--shadow);
+      font-weight:600;
+      opacity:0;
+      pointer-events:none;
+      transition:transform .25s ease, opacity .22s ease;
+      z-index:120;
+    }
+    .toast.show{opacity:1;pointer-events:auto;transform:translate(-50%, -4px);}
+    #actionBar{
+      position:fixed;
+      left:50%;
+      transform:translateX(-50%);
+      bottom:calc(16px + var(--safe-bottom));
+      width:min(560px,calc(100vw - 28px));
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      gap:14px;
+      padding:16px 18px;
+      background:rgba(20,23,34,.96);
+      border:1px solid rgba(255,255,255,.08);
+      border-radius:18px;
+      box-shadow:var(--shadow);
+      backdrop-filter:blur(14px);
+      z-index:50;
+      transition:opacity .2s ease, transform .24s ease;
+    }
+    #actionBar.hidden{opacity:0;pointer-events:none;transform:translate(-50%, 40px);}
+    #actionHint{font-size:14px;line-height:1.4;}
+    #shareRow{display:none;align-items:center;gap:12px;margin-bottom:18px;}
+    #shareRow input{flex:1;}
+    .section-title{display:flex;align-items:center;justify-content:space-between;gap:12px;margin:28px 0 14px;}
+    .winner-card{background:linear-gradient(135deg,rgba(37,208,162,.22),rgba(124,92,255,.22));border:1px solid rgba(124,92,255,.3);border-radius:22px;padding:20px;}
+    .placeholder{color:var(--muted);font-size:14px;padding:12px 0;}
+    dialog{border:none;border-radius:24px;padding:0;background:rgba(11,13,19,.94);color:var(--text);box-shadow:0 28px 64px rgba(0,0,0,.6);}
+    dialog::backdrop{background:rgba(5,7,11,.72);}
+    dialog form{padding:24px;max-height:80vh;overflow:auto;}
+    menu{margin:0;padding:0;display:flex;gap:12px;justify-content:flex-end;}
+    #menuSheet{
+      position:fixed;
+      right:16px;
+      top:74px;
+      background:rgba(16,19,29,.96);
+      border:1px solid rgba(255,255,255,.08);
+      border-radius:18px;
+      padding:16px;
+      display:flex;
+      flex-direction:column;
+      gap:8px;
+      min-width:200px;
+      box-shadow:var(--shadow);
+      z-index:60;
+    }
+    #menuSheet.hidden{display:none;}
+    .menu-btn{width:100%;text-align:left;}
+    @media (max-width:640px){
+      header{padding:16px 14px 10px;}
+      .wrap{padding:0 14px 160px;}
+      .card, .black-card{padding:20px;}
+      .cards-grid{grid-template-columns:1fr;}
+      .primary, .ghost-rounded{font-size:16px;}
+      #shareRow{flex-direction:column;align-items:stretch;}
+      table.scoreboard td{font-size:15px;}
     }
   </style>
 </head>
 <body>
+  <header>
+    <div class="logo" aria-live="polite">🃏 <b>500 зл. карт</b></div>
+    <button id="menuBtn" class="icon-btn" aria-label="Меню">☰</button>
+    <div id="menuSheet" class="hidden" role="menu">
+      <button class="ghost-rounded menu-btn" id="menuRules" role="menuitem">Правила</button>
+      <button class="ghost-rounded menu-btn" id="menuDeck" role="menuitem">Колода</button>
+      <button class="ghost-rounded menu-btn" id="menuTests" role="menuitem">🧪 Тесты</button>
+      <button class="ghost-rounded menu-btn" id="menuCheck" role="menuitem">Проверка соединения</button>
+      <button class="ghost-rounded menu-btn" id="menuNew" role="menuitem">Новая игра</button>
+    </div>
+  </header>
   <div class="wrap">
-    <header>
-      <div class="logo">🃏 <b>500 зл. карт</b> — онлайн</div>
-      <div class="bar">
-        <span id="connStatus" class="chip" title="Проверка соединения">Статус: не проверено</span>
-        <button class="ghost" id="btnCheck">Проверить соединение</button>
-        <button class="ghost" id="btnDeck">Колода</button>
-        <button class="ghost" id="btnHow">Правила</button>
-        <button class="ghost" id="btnTests">🧪 Тесты</button>
-        <button id="btnNew">Новая игра</button>
-        <button class="ghost hidden" id="btnToJudge">→ Фаза судьи</button>
-      </div>
-    </header>
-
-    <!-- ЭКРАН ЛОББИ / ПОДКЛЮЧЕНИЕ -->
-    <div class="grid" id="screenLobby">
-      <section class="panel">
-        <h2>Подключение к игре</h2>
-        <p class="muted">1) Ведущий создаёт комнату → кидает ссылку друзьям. 2) Все открывают ссылку и вводят имя. 3) Игра синхронизируется между устройствами.</p>
-        <div class="row">
-          <button id="btnCreate">Создать комнату</button>
-          <input type="text" id="roomInput" placeholder="ID комнаты (например, ABC123)" style="max-width:220px">
-          <button class="ghost" id="btnJoin">Присоединиться</button>
+    <main id="screenCreate" class="active" aria-live="polite">
+      <section class="card">
+        <h1>Создать комнату</h1>
+        <p class="muted">Придумайте имя и поделитесь ссылкой с друзьями. Игра стартует автоматически, когда присоединится минимум один игрок.</p>
+        <div class="field-gap">
+          <label>Ваше имя
+            <input type="text" id="createName" maxlength="24" autocomplete="name" placeholder="Например, Катя" aria-required="true" />
+          </label>
+          <label>ID комнаты
+            <input type="text" id="createRoomId" maxlength="8" autocomplete="off" aria-required="true" />
+          </label>
         </div>
-        <div class="hr"></div>
-        <div class="row">
-          <input type="text" id="playerName" placeholder="Ваше имя" style="max-width:240px">
-          <label><input type="checkbox" id="sfwOnly" checked> Только SFW</label>
-        </div>
-        <p class="small muted">Ссылка на комнату появится после создания. Откройте эту страницу на телефоне.</p>
-        <div class="row" id="shareRow" style="margin-top:8px; display:none;">
-          <input type="text" id="shareLink" readonly>
-          <button class="ghost" id="btnCopy">Скопировать ссылку</button>
-        </div>
-        <div id="lobbyInfo" class="muted" style="margin-top:8px;"></div>
-      </section>
-    </div>
-
-    <!-- ЭКРАН ИГРЫ -->
-    <div class="grid hidden" id="screenGame">
-      <section class="panel split">
-        <div class="kicker">
-          <div>
-            <div class="muted small">Комната: <span id="roomIdLabel">—</span></div>
-            <div class="muted small">Раунд <span id="roundN">1</span>/<span id="roundTotal">10</span></div>
-            <div style="margin-top:2px;">Судья: <b id="judgeName">—</b></div>
-          </div>
-          <div class="chips"><span class="chip" id="turnHint">Фаза: —</span></div>
-        </div>
-
-        <div class="card" style="margin-top:12px;">
-          <div class="muted small">Чёрная карта</div>
-          <div id="blackText" class="big" style="margin-top:6px;">—</div>
-        </div>
-
-        <div id="phaseHands" style="margin-top:14px;">
-          <h3>Ваши карты</h3>
-          <div class="muted small">Выберите одну белую карту (ваша рука видна только вам)</div>
-          <div class="cards" id="handCards" style="margin-top:10px;"></div>
-        </div>
-
-        <div id="phaseJudge" class="hidden" style="margin-top:14px;">
-          <h3>Выбор победителя (судья)</h3>
-          <div class="muted small">Судья <b id="judgeName2">—</b>, выберите лучший ответ:</div>
-          <div class="cards" id="submissions" style="margin-top:10px;"></div>
-        </div>
-
-        <div id="phaseWinner" class="hidden" style="margin-top:14px;">
-          <div class="card winner">
-            <div class="muted small">Победитель раунда</div>
-            <div class="big" id="winnerLine" style="margin-top:6px;">—</div>
-            <div class="row" style="margin-top:10px;">
-              <button id="nextRound">Следующий раунд (ведущий)</button>
-            </div>
-          </div>
+        <div class="actions-row">
+          <button id="btnCreateRoom" class="primary">Создать комнату</button>
+          <span id="createError" class="muted" style="color:#ffb1c5;min-height:20px;" aria-live="assertive"></span>
         </div>
       </section>
+    </main>
 
-      <aside class="panel side">
-        <h2>Игроки</h2>
-        <div id="playersList" class="scroll"></div>
-        <div class="hr"></div>
-        <div class="row">
-          <span class="small muted">Ведущий управляет раундами</span>
+    <main id="screenJoin" aria-live="polite">
+      <section class="card">
+        <h1>Войти в комнату</h1>
+        <p class="muted">Ведущий уже запустил комнату. Введите имя, чтобы присоединиться.</p>
+        <div class="field-gap">
+          <label>Ваше имя
+            <input type="text" id="joinName" maxlength="24" autocomplete="name" placeholder="Например, Лёша" aria-required="true" />
+          </label>
         </div>
-      </aside>
-    </div>
+        <div class="actions-row">
+          <button id="btnJoinRoom" class="primary">Присоединиться</button>
+          <span id="joinError" class="muted" style="color:#ffb1c5;min-height:20px;" aria-live="assertive"></span>
+        </div>
+      </section>
+    </main>
 
-    <!-- МОДАЛКИ -->
-    <dialog id="dlgRules">
-      <form method="dialog" class="card" style="min-width:min(680px,90vw);">
-        <h2>Правила (коротко)</h2>
-        <ol class="muted" style="line-height:1.6;">
-          <li>Один создаёт комнату и становится ведущим (host).</li>
-          <li>Все вводят имя и заходят по ссылке комнаты.</li>
-          <li>Каждый раунд судья меняется по кругу.</li>
-          <li>Игроки выбирают ответы из своей руки, судья выбирает лучший.</li>
-          <li>Победитель получает 1 очко.</li>
-        </ol>
-        <menu class="row" style="justify-content:flex-end; margin-top:8px;">
-          <button class="ghost">Закрыть</button>
-        </menu>
-      </form>
-    </dialog>
-
-    <dialog id="dlgDeck">
-      <form method="dialog" class="card" style="min-width:min(880px,96vw);">
-        <h2>Колода</h2>
-        <p class="muted">Редактируйте или импортируйте JSON. Формат: <span class="mono">{"black":[],"white":[],"nsfwBlack":[],"nsfwWhite":[]}</span></p>
-        <div class="row"><textarea id="deckJson" rows="12" style="width:100%"></textarea></div>
-        <div class="row" style="justify-content:space-between;margin-top:8px;">
-          <div class="row">
-            <button type="button" class="ghost" id="btnImport">Импорт JSON…</button>
-            <button type="button" class="ghost" id="btnExport">Экспорт JSON</button>
-            <button type="button" class="ghost" id="btnResetDeck">Сбросить к демо</button>
+    <main id="screenGame" aria-live="polite">
+      <section class="card" id="shareSection">
+        <div id="shareRow">
+          <input type="text" id="shareLink" readonly aria-label="Ссылка на комнату" />
+          <button id="btnCopyLink" class="ghost-rounded">Скопировать ссылку</button>
+        </div>
+        <div class="status-board">
+          <span class="chip" id="connStatus">Статус: не проверено</span>
+          <span class="chip" id="timerChip" aria-live="polite" hidden>⏱ 60s</span>
+          <span class="chip" id="progressChip" hidden>0/0</span>
+          <span class="chip" id="roleChip" hidden>—</span>
+        </div>
+        <div class="black-card" aria-live="polite">
+          <div class="muted">Чёрная карта</div>
+          <div id="blackText" style="margin-top:10px;font-size:20px;line-height:1.5;">—</div>
+        </div>
+        <div class="muted small" id="hostSummary" aria-live="polite">Статус: ожидание.</div>
+        <div class="section-title">
+          <h2>Ваши карты</h2>
+        </div>
+        <div class="muted small" id="handHint" aria-live="polite">Ожидаем раздачу.</div>
+        <div class="cards-grid" id="handCards" style="margin-top:14px;"></div>
+        <div id="submittedCard" class="winner-card" style="margin-top:16px;display:none;">
+          <div class="muted small">Вы отправили</div>
+          <div id="submittedText" style="margin-top:8px;font-size:18px;line-height:1.45;">—</div>
+        </div>
+        <div class="section-title" style="margin-top:28px;">
+          <h2>Ответы на столе</h2>
+        </div>
+        <div id="submissionsHint" class="muted small" aria-live="polite">Ждём игроков.</div>
+        <div id="submissionsList" class="cards-grid" style="margin-top:14px;"></div>
+        <div id="resultBlock" class="winner-card" style="margin-top:28px;display:none;">
+          <div class="muted small">Победитель раунда</div>
+          <div id="winnerLine" style="margin-top:10px;font-size:18px;line-height:1.5;">—</div>
+          <div class="actions-row" style="margin-top:16px;">
+            <button id="btnNextRound" class="primary">Следующий раунд</button>
+            <span id="resultHint" class="muted small"></span>
           </div>
-          <menu class="row">
-            <button class="ghost">Закрыть</button>
-            <button type="button" id="btnSaveDeck">Сохранить</button>
-          </menu>
         </div>
-      </form>
-    </dialog>
+      </section>
 
-    <dialog id="dlgTests">
-      <form method="dialog" class="card" style="min-width:min(780px,96vw);">
-        <h2>Результаты тестов</h2>
-        <div id="testsOutput" class="mono small" style="white-space:pre-wrap"></div>
-        <menu class="row" style="justify-content:flex-end; margin-top:8px;">
-          <button class="ghost">Закрыть</button>
-        </menu>
-      </form>
-    </dialog>
+      <section class="card" style="margin-top:18px;">
+        <div class="section-title" style="margin:0 0 14px;">
+          <h2>Игроки</h2>
+        </div>
+        <div class="scroll" id="playersList" aria-live="polite"></div>
+      </section>
+    </main>
   </div>
 
-  <div id="toast" class="toast hidden"></div>
+  <div id="actionBar" class="hidden" role="status" aria-live="polite">
+    <div id="actionHint">Выберите карту и подтвердите.</div>
+    <button id="btnConfirm" class="primary" disabled>Подтвердить</button>
+  </div>
 
-  <!-- Firebase (compat для простоты) -->
+  <div id="toast" class="toast" role="status" aria-live="polite"></div>
+
+  <dialog id="dlgRules">
+    <form method="dialog">
+      <h2>Правила</h2>
+      <ol class="muted" style="line-height:1.6;">
+        <li>Модератор создаёт комнату, делится ссылкой и управляет игрой.</li>
+        <li>Каждый раунд один из игроков становится ведущим и выбирает лучшую карту.</li>
+        <li>Ведущий не получает белых карт, остальные получают по 7 карт.</li>
+        <li>Ответы анонимны до объявления победителя. Таймер раунда — 60 секунд.</li>
+        <li>Победитель получает 1 очко, роли ведущего ротируются по очереди игроков.</li>
+      </ol>
+      <menu>
+        <button class="ghost-rounded">Закрыть</button>
+      </menu>
+    </form>
+  </dialog>
+
+  <dialog id="dlgDeck">
+    <form method="dialog">
+      <h2>Колода</h2>
+      <p class="muted">JSON-формат: <span style="font-family:ui-monospace;">{"black":[],"white":[],"nsfwBlack":[],"nsfwWhite":[]}</span>. Минимум 120 чёрных и 500 белых.</p>
+      <textarea id="deckJson" rows="12"></textarea>
+      <menu style="margin-top:16px;justify-content:space-between;align-items:center;">
+        <div style="display:flex;gap:10px;">
+          <button type="button" class="ghost-rounded" id="btnImportDeck">Импорт…</button>
+          <button type="button" class="ghost-rounded" id="btnExportDeck">Экспорт</button>
+          <button type="button" class="ghost-rounded" id="btnResetDeck">Сбросить</button>
+        </div>
+        <div style="display:flex;gap:10px;">
+          <button class="ghost-rounded">Закрыть</button>
+          <button type="button" class="primary" id="btnSaveDeck">Сохранить</button>
+        </div>
+      </menu>
+    </form>
+  </dialog>
+
+  <dialog id="dlgTests">
+    <form method="dialog">
+      <h2>Результаты тестов</h2>
+      <pre id="testsOutput" style="font-family:ui-monospace;white-space:pre-wrap;font-size:13px;line-height:1.5;">—</pre>
+      <menu style="margin-top:16px;">
+        <button class="ghost-rounded">Закрыть</button>
+      </menu>
+    </form>
+  </dialog>
+
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-database-compat.js"></script>
-
   <script>
-  // ===== УТИЛИТЫ =====
-  const $ = s => document.querySelector(s);
-  const $$ = s => Array.from(document.querySelectorAll(s));
-  const uid = () => Math.random().toString(36).slice(2, 10);
-  const shuffle = arr => { for (let i = arr.length - 1; i > 0; i--) { const j = Math.floor(Math.random() * (i + 1)); [arr[i], arr[j]] = [arr[j], arr[i]]; } return arr; };
-  const toast = (msg)=>{ const t=$('#toast'); t.textContent=msg; t.classList.remove('hidden'); setTimeout(()=>t.classList.add('hidden'), 2000); };
+  const STATUS = { LOBBY:'lobby', COLLECT:'collect', RESULT:'result' };
+  const MIN_PLAYERS = 2;
+  const ROUNDS_TOTAL = 10;
+  const ROUND_TIMER_SECONDS = 60;
+  const STORAGE_KEY = 'zlobnye_karty_deck_v2';
+  const EVENTS_PATH = 'events';
 
-  // ===== КОЛОДА SFW + автогенерация =====
-  const DEMO_DECK = { black:[
-    "Лучшее средство от плохого настроения — ____.",
-    "В офисе запретили ____ после прошлой вечеринки.",
-    "Мой тайный талант — ____.",
-    "Комбо дня: ____ с соусом из ____.",
-    "На первом свидании не советую обсуждать ____.",
-    "Ученые наконец-то придумали ____.",
-    "Самое неожиданное в подарок — ____.",
-    "Новое хобби, о котором стыдно рассказать родителям: ____.",
-    "Завтрак чемпиона — ____.",
-    "Путь к успеху начинается с ____.",
+  const $ = (s)=>document.querySelector(s);
+  const $$ = (s)=>Array.from(document.querySelectorAll(s));
+  const uid = ()=>Math.random().toString(36).slice(2,10);
+  const now = ()=>Date.now();
+  const shuffle = arr=>{ for(let i=arr.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); [arr[i],arr[j]]=[arr[j],arr[i]]; } return arr; };
+  const escapeHtml = str=>{ const map={ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;' }; return String(str||'').replace(/[&<>"']/g,ch=>map[ch]); };
+  const fillBlack = (black,white)=>{ const safe=escapeHtml(white||'—'); return (black||'').includes('____') ? (black||'—').replace('____',`<b>${safe}</b>`) : `${escapeHtml(black||'—')} — <b>${safe}</b>`; };
+  const copyToClipboard = async(text)=>{ try{ await navigator.clipboard.writeText(text); toast('Ссылка скопирована'); }catch(e){ showError(e); } };
+
+  let toastTimer=null;
+  function toast(msg){ const el=$('#toast'); if(!el) return; el.textContent=msg; el.classList.add('show'); clearTimeout(toastTimer); toastTimer=setTimeout(()=>el.classList.remove('show'),2400); }
+  function normalizeError(err){ if(!err) return 'Неизвестная ошибка'; if(typeof err==='string') return err; const code=err.code||''; if(code.includes('network')) return 'Нет соединения с Firebase.'; if(code.includes('permission')) return 'Недостаточно прав Firebase.'; if(code.includes('timeout')) return 'Время ожидания истекло.'; return err.message||'Что-то пошло не так.'; }
+  function showError(err){ console.error(err); toast('Ошибка: '+normalizeError(err)); }
+
+  const DEMO_DECK={ black:[
+    'Лучшее средство от плохого настроения — ____.',
+    'В офисе запретили ____ после прошлой вечеринки.',
+    'Мой тайный талант — ____.',
+    'Комбо дня: ____ с соусом из ____.',
+    'На первом свидании не советую обсуждать ____.',
+    'Учёные наконец-то придумали ____.',
+    'Самое неожиданное в подарок — ____.',
+    'Новое хобби, о котором стыдно рассказать родителям: ____.',
+    'Завтрак чемпиона — ____.',
+    'Путь к успеху начинается с ____.',
   ], white:[
-    "йога при свете лампы","безлимитные мемы","кот, который судит тебя","презентация на 200 слайдов","звуки леса в 3 часа ночи","микродозы энтузиазма","ежедневник на 2035 год","кофе уровня босс","танец с пылесосом","срочный созвон ни о чем","переписка с самим собой","зарядка для лица и совести","подкаст, который никто не слушает","коллекция несбывшихся целей","плед ответственности","удаленная пятница","загадочный дедлайн","ночной поход в холодильник","тик-ток для взрослых — чтение","случайный акт продуктивности"
+    'йога при свете лампы','безлимитные мемы','кот, который судит тебя','презентация на 200 слайдов','звуки леса в 3 часа ночи','микродозы энтузиазма','ежедневник на 2035 год','кофе уровня босс','танец с пылесосом','срочный созвон ни о чём','переписка с самим собой','зарядка для лица и совести','подкаст, который никто не слушает','коллекция несбывшихся целей','плед ответственности','удалённая пятница','загадочный дедлайн','ночной поход в холодильник','тик-ток для взрослых — чтение','случайный акт продуктивности'
   ], nsfwBlack:[], nsfwWhite:[] };
 
   function ensureMinimumDeck(base){
     const MIN_BLACK=120, MIN_WHITE=500;
-    const adj=["бескомпромиссный","легендарный","скромный","хрупкий","стальной","мягкий","неудобный","удивительный","космический","тактический","нулевой","случайный","домашний","турбо","антистресс","чистосердечный","ботанский","карманный","праздничный","грустный","героический","виноватый","странный","панический","осознанный","вафельный","экологичный","умный","сверхважный","необъяснимый"];
-    const noun=["кактус","ежедневник","кекс","плед","римейк детства","кот в коробке","танец победителя","утренний ритуал","план Б","зум-созвон","марафон сериалов","пакет багов","диванный стартап","апдейт настроения","чай без сахара","стакан воды","неловкая пауза","электронная очередь","перерыв на себя","похвала самому себе","карта желаний","фантазия","чистый стол","новый понедельник","таймер на 5 минут","пища для ума","сон днём","упражнение на растяжку","вдох через нос","молчаливое согласие"];
-    const tails=["в подарок","в 3 часа ночи","по подписке","на скорую руку","в режиме инкогнито","без уведомлений","с доставкой завтра","по любви","на удалёнке","с закрытыми глазами","с одобрения кота","вместо спорта","вдохновляющей формы","без инструкции","с минимальными усилиями","в последнюю секунду","с видом на кухню","в пределах разумного","на полном серьёзе","для галочки","с огоньком","по выходным","для души","под настроение","как-нибудь потом","в хорошем смысле","не для отчёта","по приколу","по старой памяти","без причин"];
-    function genWhite(i){ return `${adj[i%adj.length]} ${noun[(i*7)%noun.length]} ${tails[(i*13)%tails.length]}`; }
-    const blackStarts=["Мой день начинается с ____.","На совещании лучше не обсуждать ____.","Секрет успешного проекта — ____.","Сегодняшний план: кофе, дела и ____.","Самый странный подарок — ____.","Я бы с радостью заменил(а) гимн на ____.","Когда никто не видит, я практикую ____.","Лучшее, что можно добавить в резюме — ____.","Идеальное алиби: ____.","Главный антистресс — ____.","Спорим, в 2035 мы будем платить за ____.","В корпоративном чате забанили тему ____.","Главная фича нового айфона — ____.","Если бы у меня был слоган, он бы был про ____.","На TED я выступлю про ____.","Мой внутренний критик обожает ____.","Шеф мечтает внедрить ____.","User story на сегодня — ____.","Я официально отказываюсь от ____.","Сегодня отменяется всё, кроме ____."];
-    const needW=Math.max(0, MIN_WHITE-(base.white?.length||0)); for(let i=0;i<needW;i++) base.white.push(genWhite(i));
-    const needB=Math.max(0, MIN_BLACK-(base.black?.length||0)); for(let i=0;i<needB;i++) base.black.push(blackStarts[i%blackStarts.length]);
+    const adj=['бескомпромиссный','легендарный','скромный','хрупкий','стальной','мягкий','неудобный','удивительный','космический','тактический','нулевой','случайный','домашний','турбо','антистресс','чистосердечный','ботанский','карманный','праздничный','грустный','героический','виноватый','странный','панический','осознанный','вафельный','экологичный','умный','сверхважный','необъяснимый'];
+    const noun=['кактус','ежедневник','кекс','плед','римейк детства','кот в коробке','танец победителя','утренний ритуал','план Б','зум-созвон','марафон сериалов','пакет багов','диванный стартап','апдейт настроения','чай без сахара','стакан воды','неловкая пауза','электронная очередь','перерыв на себя','похвала самому себе','карта желаний','фантазия','чистый стол','новый понедельник','таймер на 5 минут','пища для ума','сон днём','упражнение на растяжку','вдох через нос','молчаливое согласие'];
+    const tails=['в подарок','в 3 часа ночи','по подписке','на скорую руку','в режиме инкогнито','без уведомлений','с доставкой завтра','по любви','на удалёнке','с закрытыми глазами','с одобрения кота','вместо спорта','в хорошем смысле','без инструкции','с минимальными усилиями','в последнюю секунду','с видом на кухню','в пределах разумного','на полном серьёзе','для галочки','с огоньком','по выходным','для души','под настроение','как-нибудь потом','по приколу','по старой памяти','без причин'];
+    const seeds=['Мой день начинается с ____.','На совещании лучше не обсуждать ____.','Секрет успешного проекта — ____.','Сегодняшний план: кофе, дела и ____.','Самый странный подарок — ____.','Я бы с радостью заменил(а) гимн на ____.','Когда никто не видит, я практикую ____.','Лучшее, что можно добавить в резюме — ____.','Идеальное алиби: ____.','Главный антистресс — ____.','Спорим, в 2035 мы будем платить за ____.','В корпоративном чате забанили тему ____.','Главная фича нового айфона — ____.','Если бы у меня был слоган, он бы был про ____.','На TED я выступлю про ____.','Мой внутренний критик обожает ____.','Шеф мечтает внедрить ____.','User story на сегодня — ____.','Я официально отказываюсь от ____.','Сегодня отменяется всё, кроме ____.'];
+    const needW=Math.max(0,MIN_WHITE-(base.white?.length||0));
+    for(let i=0;i<needW;i++){ base.white.push(`${adj[i%adj.length]} ${noun[(i*7)%noun.length]} ${tails[(i*13)%tails.length]}`); }
+    const needB=Math.max(0,MIN_BLACK-(base.black?.length||0));
+    for(let i=0;i<needB;i++){ base.black.push(seeds[i%seeds.length]); }
   }
 
-  // ===== Firebase init (заполните конфиг) =====
-  const FIREBASE_CONFIG = {
-    apiKey: "AIzaSyDRtpegXwTsSf77dPIOGDIyBFvib_GgUcM",
-    authDomain: "z-e86ee.firebaseapp.com",
-    databaseURL: "https://z-e86ee-default-rtdb.europe-west1.firebasedatabase.app",
-    projectId: "z-e86ee",
-    storageBucket: "z-e86ee.appspot.com",
-    messagingSenderId: "268263276853",
-    appId: "1:268263276853:web:0195c839f5dd38e7214c7c",
-    measurementId: "G-6ZBVR66GZE"
+  const game={
+    state:{ status:STATUS.LOBBY, round:0, roundsTotal:ROUNDS_TOTAL, blackCard:'', lastWinnerName:'', lastAnswer:'', currentHostPid:null, currentHostName:'', timerEndsAt:null },
+    players:{},
+    playersOrder:[],
+    submissions:{},
+    submissionsOrder:[],
+    deck:{ black:[], white:[], discardBlack:[], discardWhite:[] }
   };
 
-  function isConfigFilled(cfg){
-    return Object.values(cfg).every(v=> typeof v==='string' && v && !v.startsWith('PASTE_')) && /https:\/\/.+/.test(cfg.databaseURL||'');
-  }
+  const local={
+    playerId: localStorage.getItem('playerId') || uid(),
+    roomId:null,
+    name:'',
+    isCreator:false,
+    hasSubmitted:false,
+    selectedIndex:null,
+    selectedText:'',
+    submittedText:'',
+    timerInterval:null,
+    autoPickFired:false,
+    activeHand:[]
+  };
+  localStorage.setItem('playerId', local.playerId);
 
-  let db = null; let firebaseInitError = null; let connectivityOk = false; let lastConnMsg = '';
-  try {
-    if (!isConfigFilled(FIREBASE_CONFIG)) throw new Error('Не заполнен FIREBASE_CONFIG');
-    firebase.initializeApp(FIREBASE_CONFIG);
-    db = firebase.database();
-  } catch (e){
-    firebaseInitError = e;
-    console.error('Firebase init error:', e);
+  function loadDeckLocal(){
+    let base; const raw=localStorage.getItem(STORAGE_KEY);
+    if(raw){ try{ base=JSON.parse(raw); }catch(e){ base=JSON.parse(JSON.stringify(DEMO_DECK)); } }
+    else base=JSON.parse(JSON.stringify(DEMO_DECK));
+    ensureMinimumDeck(base);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(base));
+    game.deck.black=shuffle([...base.black]);
+    game.deck.white=shuffle([...base.white]);
+    game.deck.discardBlack=[];
+    game.deck.discardWhite=[];
+    if($('#deckJson')) $('#deckJson').value=JSON.stringify(base,null,2);
   }
+  function drawBlack(){ if(!game.deck.black.length){ game.deck.black=shuffle([...game.deck.discardBlack]); game.deck.discardBlack=[]; } return game.deck.black.pop()||'—'; }
+  function drawWhite(){ if(!game.deck.white.length){ game.deck.white=shuffle([...game.deck.discardWhite]); game.deck.discardWhite=[]; } return game.deck.white.pop()||'—'; }
+  function topUpHand(hand,target=7){ const arr=[...(hand||[])]; while(arr.length<target){ arr.push(drawWhite()); } return arr; }
+
+  const FIREBASE_CONFIG={
+    apiKey:"AIzaSyDRtpegXwTsSf77dPIOGDIyBFvib_GgUcM",
+    authDomain:"z-e86ee.firebaseapp.com",
+    databaseURL:"https://z-e86ee-default-rtdb.europe-west1.firebasedatabase.app",
+    projectId:"z-e86ee",
+    storageBucket:"z-e86ee.appspot.com",
+    messagingSenderId:"268263276853",
+    appId:"1:268263276853:web:0195c839f5dd38e7214c7c",
+    measurementId:"G-6ZBVR66GZE"
+  };
+
+  let db=null, firebaseInitError=null, connectivityOk=false, lastConnMsg='';
+  try{ firebase.initializeApp(FIREBASE_CONFIG); db=firebase.database(); }catch(e){ firebaseInitError=e; console.error('Firebase init error',e); }
 
   async function testDbConnection(){
-    if (!db){ lastConnMsg='Firebase не инициализирован'; updateConnStatus(false,lastConnMsg); return false; }
-    try {
-      const pingRef = db.ref('_ping').push();
-      await pingRef.set({ t: Date.now(), ua: navigator.userAgent.substring(0,80) });
-      await pingRef.remove();
+    if(!db){ lastConnMsg='Firebase не инициализирован'; updateConnStatus(false,lastConnMsg); return false; }
+    try{
+      const ping=db.ref('_ping').push();
+      await ping.set({ t:now(), ua:navigator.userAgent.slice(0,80) });
+      await ping.remove();
       lastConnMsg='OK: есть доступ к Realtime DB';
       updateConnStatus(true,lastConnMsg);
       return true;
-    } catch(e){
-      console.error('DB write test failed', e);
-      lastConnMsg = (e && (e.code||e.message)) || 'ошибка записи в БД';
+    }catch(e){
+      lastConnMsg=normalizeError(e);
       updateConnStatus(false,lastConnMsg);
       return false;
     }
   }
+  function updateConnStatus(ok,msg){ const el=$('#connStatus'); if(!el) return; el.textContent='Статус: '+(ok?'подключено':'ошибка'); el.title=msg||''; el.style.background=ok?'var(--accent-2)':'var(--chip)'; }
 
-  // ===== ЛОГИКА КОМНАТЫ / СОСТОЯНИЕ =====
-  const STORAGE_KEY = 'zlobnye_karty_deck_v1';
-  const local = { playerId: localStorage.getItem('playerId') || uid(), name:'', roomId:null, isHost:false };
-  localStorage.setItem('playerId', local.playerId);
-
-  const game = { state: { round:0, roundsTotal:10, judgeIndex:0, phase:'lobby', blackCard:'', sfwOnly:true },
-                 deck: { black:[], white:[], discardBlack:[], discardWhite:[] } };
-
-  function fillBlack(black, white){
-    return black.includes('____') ? black.replace('____', `<b>${escapeHtml(white)}</b>`) : `${black} — <b>${escapeHtml(white)}</b>`;
-  }
-  function escapeHtml(str){
-    const map = { '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' };
-    return String(str).replace(/[&<>"']/g, ch => map[ch]);
-  }
-
-  // ===== Работа с колодой (на стороне ведущего) =====
-  function loadDeckLocal(){
-    const raw = localStorage.getItem(STORAGE_KEY); let base = DEMO_DECK; if (raw){ try{ base = JSON.parse(raw);}catch(e){ console.warn('Bad deck JSON'); } }
-    ensureMinimumDeck(base);
-    const black=[...base.black], white=[...base.white];
-    game.deck.black = shuffle(black); game.deck.white = shuffle(white);
-    $('#deckJson').value = JSON.stringify(base, null, 2);
-  }
-  function drawBlack(){ if(!game.deck.black.length){ game.deck.black = shuffle(game.deck.discardBlack); game.deck.discardBlack = []; } return game.deck.black.pop() || '— пусто —'; }
-  function drawWhite(){ if(!game.deck.white.length){ game.deck.white = shuffle(game.deck.discardWhite); game.deck.discardWhite = []; } return game.deck.white.pop() || '— пусто —'; }
-
-  // ===== Firebase helpers =====
-  const roomRef = ()=> db.ref(`rooms/${local.roomId}`);
-  const playersRef = ()=> roomRef().child('players');
-  const stateRef = ()=> roomRef().child('state');
-  const perPlayerRef = (pid)=> roomRef().child(`perPlayer/${pid}`); // руки
-  const submissionsRef = ()=> roomRef().child('submissions');
-
-  // Хелпер: синхронизируем роль хоста при любых перезаходах
-  function watchHost(){
-    roomRef().child('hostId').on('value', snap => {
-      const was = local.isHost;
-      local.isHost = (snap.val() === local.playerId);
-      if (local.isHost !== was) renderState();
-    });
-  }
-
-  async function createRoom(){
-    if (!db){ toast('Ошибка: Firebase не инициализирован. Заполните конфиг.'); console.error(firebaseInitError); return; }
-    if (!connectivityOk){ const ok = await testDbConnection(); if(!ok){ toast('Нет доступа к базе. Проверьте конфиг/правила.'); return; } connectivityOk=true; }
-    const id = (Math.random().toString(36).slice(2,8)).toUpperCase();
-    local.roomId = id; local.isHost = true;
-    loadDeckLocal();
-    try{
-      await roomRef().set({ hostId: local.playerId, createdAt: Date.now() });
-      await stateRef().set({ ...game.state, phase:'lobby', sfwOnly: $('#sfwOnly').checked });
-      await db.ref(`rooms/${local.roomId}/deck`).set({ black: game.deck.black, white: game.deck.white });
-      updateShareLink();
-      subscribeRoom();
-      watchHost();
-      subscribeHostEvents();
-      await registerPlayer();
-      renderState();
-      toast('Комната создана');
-    } catch(e){ console.error('createRoom error', e); toast('Не удалось создать комнату: ' + (e.code||e.message)); }
-  }
-
-  async function joinRoom(id){
-    if (!db){ toast('Ошибка: Firebase не инициализирован'); console.error(firebaseInitError); return; }
-    const ok = connectivityOk || await testDbConnection(); if(!ok){ toast('Нет доступа к базе. Проверьте конфиг/правила.'); return; } connectivityOk=true;
-    local.roomId = id.toUpperCase();
-    local.isHost = false;
-    subscribeRoom();
-    watchHost();
-    try{ await registerPlayer(); toast('Подключились к комнате'); } catch(e){ console.error('joinRoom/register error', e); toast('Не удалось подключиться: ' + (e.code||e.message)); }
-  }
-
-  let playersCount = 0;
-  function subscribeRoom(){
-    if (!db || !local.roomId) return;
-    stateRef().off(); playersRef().off(); submissionsRef().off(); perPlayerRef(local.playerId).off();
-    stateRef().on('value', snap=>{ const s=snap.val(); if(!s) return; game.state = s; renderState(); });
-    playersRef().on('value', snap=>{ const players = snap.val()||{}; playersCount = Object.keys(players).length; renderPlayers(players); maybeAutoStart(players); });
-    submissionsRef().on('value', snap=>{ renderSubmissions(snap.val()||{}); });
-    perPlayerRef(local.playerId).on('value', snap=>{ renderHand((snap.val()&&snap.val().hand)||[]); });
-  }
-
-  async function registerPlayer(){
-    if (!local.roomId) return;
-    local.name = ($('#playerName').value || localStorage.getItem('playerName') || '').trim();
-    if (!local.name) { local.name = 'Игрок ' + local.playerId.slice(-4); }
-    localStorage.setItem('playerName', local.name);
-    const pRef = playersRef().child(local.playerId);
-    await pRef.set({ name: local.name, score:0, isJudge:false, joinedAt: Date.now() });
-    await pRef.onDisconnect().remove();
-    // выдать руку (ведущий)
-    if (local.isHost){
-      const hand = []; for(let i=0;i<7;i++) hand.push(drawWhite());
-      await perPlayerRef(local.playerId).set({ hand });
-    } else {
-      // попросить ведущего выдать карты
-      await roomRef().child('events').push({ type:'needHand', playerId: local.playerId, t:Date.now() });
-    }
-  }
-
-  // Ведущий слушает события
-  function subscribeHostEvents(){
-    if (!local.isHost) return;
-    roomRef().child('events').on('child_added', async snap=>{
-      const ev = snap.val() || {}; const k = snap.key;
-      if (ev.type==='needHand'){
-        const hand = []; for(let i=0;i<7;i++) hand.push(drawWhite());
-        await perPlayerRef(ev.playerId).set({ hand });
-        await roomRef().child('events').child(k).remove();
-      }
-    });
-  }
-
-  // ===== ЛОББИ/ИГРА ПЕРЕКЛЮЧЕНИЕ =====
-  function renderState(){
-    const s = game.state || {};
-    if (s.phase==='lobby'){ $('#screenLobby').classList.remove('hidden'); $('#screenGame').classList.add('hidden'); }
-    else { $('#screenLobby').classList.add('hidden'); $('#screenGame').classList.remove('hidden'); }
-    $('#roomIdLabel').textContent = local.roomId || '—';
-    $('#roundN').textContent = s.round || 0; $('#roundTotal').textContent = s.roundsTotal || 10;
-    $('#judgeName').textContent = s.judgeName || '—'; $('#judgeName2').textContent = s.judgeName || '—';
-    $('#blackText').innerHTML = escapeHtml(s.blackCard || '—');
-    $('#turnHint').textContent = 'Фаза: ' + (s.phase||'—');
-    // Фазы видимости
-    $('#phaseHands').classList.toggle('hidden', s.phase!=='hands');
-    $('#phaseJudge').classList.toggle('hidden', s.phase!=='judge');
-    $('#phaseWinner').classList.toggle('hidden', s.phase!=='winner');
-    // Кнопки ведущего
-    const showToJudge = local.isHost && s.phase==='hands';
-    $('#btnToJudge')?.classList.toggle('hidden', !showToJudge);
-  }
-
-  function renderPlayers(players){
-    const box=$('#playersList'); box.innerHTML='';
-    const arr=Object.entries(players).map(([id,p])=>({id,...p})).sort((a,b)=> (b.score||0)-(a.score||0));
-    arr.forEach(p=>{
-      const row=document.createElement('div'); row.className='kicker'; row.style.padding='6px 0';
-      row.innerHTML=`<div>${escapeHtml(p.name)} ${p.isJudge?'<span class="small muted">(судья)</span>':''}</div><div class="chip">${p.score||0}</div>`;
-      box.appendChild(row);
-    });
-  }
+  const roomRef=()=>db.ref(`rooms/${local.roomId}`);
+  const stateRef=()=>roomRef().child('state');
+  const playersRef=()=>roomRef().child('players');
+  const orderRef=()=>roomRef().child('playersOrder');
+  const submissionsRef=()=>roomRef().child('submissions');
+  const perPlayerRef=(pid)=>roomRef().child(`perPlayer/${pid}`);
+  const deckRef=()=>roomRef().child('deck');
+  const eventsRef=()=>roomRef().child(EVENTS_PATH);
 
   function orderedPlayerIds(players){
     return Object.keys(players||{}).sort((a,b)=>{
-      const ja = players[a]?.joinedAt || 0;
-      const jb = players[b]?.joinedAt || 0;
-      if (ja !== jb) return ja - jb;
+      const pa=players[a]||{}, pb=players[b]||{};
+      const ja=pa.joinedAt||0, jb=pb.joinedAt||0;
+      if(ja!==jb) return ja-jb;
       return a.localeCompare(b);
     });
   }
 
-  async function setJudgeFlags(ids, judgeId){
-    if (!ids.length) return;
-    const updates={};
-    ids.forEach(pid=>{ updates[`${pid}/isJudge`] = pid === judgeId; });
-    await playersRef().update(updates);
+  function activeOrder(){
+    const players=game.players||{};
+    return (game.playersOrder||[]).filter(id=>players[id]?.active!==false);
+  }
+  function nextHostId(order,current){
+    if(!Array.isArray(order) || !order.length) return null;
+    if(!current) return order[0];
+    const idx=order.indexOf(current);
+    return idx===-1 ? order[0] : order[(idx+1)%order.length];
+  }
+  function expectedSubmissions(){ return Math.max(0, activeOrder().length - 1); }
+
+  function unsubscribeAll(){ if(!local.roomId||!db) return; stateRef().off(); playersRef().off(); orderRef().off(); submissionsRef().off(); perPlayerRef(local.playerId).off(); eventsRef().off(); deckRef().off(); }
+
+  function subscribeRoom(){
+    if(!db || !local.roomId) return;
+    unsubscribeAll();
+    stateRef().on('value',snap=>{ const s=snap.val(); if(!s) return; game.state=s; renderState(); startTimerTick(); });
+    playersRef().on('value',snap=>{ const players=snap.val()||{}; game.players=players; renderPlayers(); if(local.isCreator) syncPlayersOrder(); ensureHostValidity(); updateProgressChip(); maybeAutoStart(); });
+    orderRef().on('value',snap=>{ const arr=snap.val(); if(Array.isArray(arr)){ game.playersOrder=arr; ensureHostValidity(); updateProgressChip(); maybeAutoStart(); } });
+    submissionsRef().on('value',snap=>{ const map=snap.val()||{}; renderSubmissions(map); });
+    perPlayerRef(local.playerId).on('value',snap=>{ const data=snap.val()||{hand:[],submitted:false,lastText:''}; local.activeHand=data.hand||[]; local.hasSubmitted=!!data.submitted; local.submittedText=data.lastText||''; renderHand(local.activeHand); updateHandState(); updateActionBar(); });
+    if(local.isCreator){
+      deckRef().on('value',snap=>{ const d=snap.val(); if(d){ game.deck.black=d.black||[]; game.deck.white=d.white||[]; game.deck.discardBlack=d.discardBlack||[]; game.deck.discardWhite=d.discardWhite||[]; } });
+      eventsRef().on('child_added',handleHostEvent);
+    }
+  }
+
+  function validateNameValue(value){
+    const trimmed=(value||'').trim();
+    if(trimmed.length<2) throw new Error('Имя слишком короткое.');
+    if(/^[0-9]+$/.test(trimmed)) throw new Error('Имя не может состоять только из цифр.');
+    return trimmed.slice(0,24);
+  }
+
+  function showScreen(id){ ['screenCreate','screenJoin','screenGame'].forEach(s=>$('#'+s).classList.remove('active')); $('#'+id).classList.add('active'); }
+  function enterGameUI(){ showScreen('screenGame'); if(local.isCreator){ $('#shareRow').style.display='flex'; updateShareLink(); } else $('#shareRow').style.display='none'; }
+  function updateShareLink(){ const url=new URL(location.href); url.searchParams.set('room', local.roomId); $('#shareLink').value=url.toString(); history.replaceState(null,'',url); }
+
+  async function registerPlayer(name){
+    const safe=name||localStorage.getItem('playerName')||`Игрок ${local.playerId.slice(-4)}`;
+    local.name=safe;
+    localStorage.setItem('playerName', safe);
+    const playerData={ name:safe, score:0, joinedAt:now(), active:true, isCreator:local.isCreator };
+    const ref=playersRef().child(local.playerId);
+    await ref.set(playerData);
+    await ref.onDisconnect().update({ active:false, leftAt:now() });
+    await perPlayerRef(local.playerId).set({ hand:[], submitted:false, lastText:'' });
+    await perPlayerRef(local.playerId).onDisconnect().remove();
+    if(!local.isCreator){
+      await orderRef().transaction(order=>{ const list=Array.isArray(order)?order.filter(id=>id!==local.playerId):[]; if(!list.includes(local.playerId)) list.push(local.playerId); return list; });
+      await eventsRef().push({ type:'needHand', playerId: local.playerId, t: now() });
+    } else {
+      await orderRef().set([local.playerId]);
+    }
+  }
+
+  async function createRoom(){
+    if(!db){ showError(firebaseInitError||'Firebase не инициализирован'); return; }
+    if(!(connectivityOk || await testDbConnection())) return;
+    try{
+      const playerName=validateNameValue($('#createName').value);
+      const roomId=($('#createRoomId').value||'').trim().toUpperCase();
+      if(roomId.length<4) throw new Error('ID комнаты должен содержать минимум 4 символа.');
+      local.roomId=roomId;
+      local.isCreator=true;
+      loadDeckLocal();
+      await roomRef().set({ creatorId:local.playerId, createdAt:now() });
+      await stateRef().set({ status:STATUS.LOBBY, round:0, roundsTotal:ROUNDS_TOTAL, blackCard:'', lastWinnerName:'', lastAnswer:'', currentHostPid:local.playerId, currentHostName:playerName, timerEndsAt:null });
+      await deckRef().set({ black:game.deck.black, white:game.deck.white, discardBlack:game.deck.discardBlack, discardWhite:game.deck.discardWhite });
+      await registerPlayer(playerName);
+      subscribeRoom();
+      enterGameUI();
+      toast('Комната создана');
+    }catch(e){ $('#createError').textContent=normalizeError(e); showError(e); }
+  }
+
+  async function joinRoom(){
+    if(!db){ showError(firebaseInitError||'Firebase не инициализирован'); return; }
+    if(!(connectivityOk || await testDbConnection())) return;
+    try{
+      const playerName=validateNameValue($('#joinName').value);
+      await registerPlayer(playerName);
+      subscribeRoom();
+      enterGameUI();
+      toast('Подключено к комнате');
+    }catch(e){ $('#joinError').textContent=normalizeError(e); showError(e); }
+  }
+
+  async function handleHostEvent(snap){
+    const ev=snap.val(); const key=snap.key;
+    if(!ev) return;
+    try{
+      if(ev.type==='needHand') await hostGiveHand(ev.playerId);
+      if(ev.type==='pickWinner') await hostPickWinner(ev.submissionId);
+      if(ev.type==='autoPick') await hostAutoPick(ev.submissionId||null);
+      if(ev.type==='nextRound') await advanceRound();
+    }catch(e){ showError(e); }
+    finally{ eventsRef().child(key).remove(); }
+  }
+
+  async function hostGiveHand(pid){
+    if(!pid) return;
+    const player=(await playersRef().child(pid).get()).val();
+    if(!player || player.active===false) return;
+    const currentHost=game.state.currentHostPid;
+    const snap=await perPlayerRef(pid).get();
+    const data=snap.val()||{hand:[],submitted:false,lastText:''};
+    const shouldHaveCards = pid!==currentHost && player.active!==false;
+    const hand = shouldHaveCards ? topUpHand(data.hand||[]) : [];
+    await perPlayerRef(pid).set({ hand, submitted:false, lastText:'' });
+    await deckRef().set({ black:game.deck.black, white:game.deck.white, discardBlack:game.deck.discardBlack, discardWhite:game.deck.discardWhite });
+  }
+
+  async function hostPickWinner(submissionId){
+    if(!submissionId) return;
+    const state=(await stateRef().get()).val();
+    if(!state || state.status!==STATUS.COLLECT) return;
+    const submissions=(await submissionsRef().get()).val()||{};
+    const entry=submissions[submissionId];
+    if(!entry) return;
+    await playersRef().child(entry.playerId).transaction(data=>{ if(!data) return data; return { ...data, score:(data.score||0)+1 }; });
+    await collectWhiteToDiscard(submissions);
+    const winnerName=game.players[entry.playerId]?.name || '—';
+    await stateRef().update({ status:STATUS.RESULT, lastWinnerName:winnerName, lastAnswer:entry.text, timerEndsAt:null });
+  }
+
+  function randomSubmissionKey(submissions, rng=Math.random){
+    const entries=Object.keys(submissions||{});
+    if(!entries.length) return null;
+    const rnd = Math.max(0, Math.min(0.999999, typeof rng==='function'?rng():Math.random()));
+    const index = Math.floor(rnd * entries.length);
+    return entries[index] || null;
+  }
+
+  async function hostAutoPick(submissionId){
+    const state=(await stateRef().get()).val();
+    if(!state || state.status!==STATUS.COLLECT) return;
+    const submissions=(await submissionsRef().get()).val()||{};
+    let pickId=submissionId;
+    if(!pickId){
+      pickId = randomSubmissionKey(submissions);
+    }
+    if(pickId && submissions[pickId]){
+      await hostPickWinner(pickId);
+    } else {
+      await collectWhiteToDiscard(submissions);
+      await stateRef().update({ status:STATUS.RESULT, lastWinnerName:'', lastAnswer:'', timerEndsAt:null });
+    }
+  }
+
+  async function collectWhiteToDiscard(submissions){
+    Object.values(submissions||{}).forEach(s=>{ if(s&&s.text) game.deck.discardWhite.push(s.text); });
+    await deckRef().set({ black:game.deck.black, white:game.deck.white, discardBlack:game.deck.discardBlack, discardWhite:game.deck.discardWhite });
+  }
+
+  async function advanceRound(){
+    if(!local.isCreator) return;
+    const state=(await stateRef().get()).val()||{};
+    const players=(await playersRef().get()).val()||{};
+    const order=activeOrder();
+    if(order.length<MIN_PLAYERS){ await stateRef().update({ status:STATUS.LOBBY, timerEndsAt:null }); return; }
+    const baseCurrent = state.status===STATUS.LOBBY ? null : state.currentHostPid;
+    const hostId = nextHostId(order, baseCurrent);
+    const hostName = players[hostId]?.name || '—';
+    if(state.blackCard){ game.deck.discardBlack.push(state.blackCard); }
+    await submissionsRef().remove();
+    const tasks=order.map(async pid=>{
+      const snap=await perPlayerRef(pid).get();
+      const data=snap.val()||{hand:[],submitted:false,lastText:''};
+      const shouldHave = pid!==hostId;
+      const hand = shouldHave ? topUpHand(data.hand||[]) : [];
+      await perPlayerRef(pid).set({ hand, submitted:false, lastText:'' });
+    });
+    await Promise.all(tasks);
+    const black=drawBlack();
+    const round = state.status===STATUS.LOBBY ? 1 : (state.round||0)+1;
+    const timerEndsAt = now() + ROUND_TIMER_SECONDS*1000;
+    await stateRef().set({ status:STATUS.COLLECT, round, roundsTotal:ROUNDS_TOTAL, blackCard:black, lastWinnerName:'', lastAnswer:'', currentHostPid:hostId, currentHostName:hostName, timerEndsAt });
+    await deckRef().set({ black:game.deck.black, white:game.deck.white, discardBlack:game.deck.discardBlack, discardWhite:game.deck.discardWhite });
+    game.submissionsOrder=[];
+  }
+
+  function simulateHandFill(order, hostId, existingHands, drawStack){
+    const deck=[...(drawStack||[])];
+    const result={};
+    (order||[]).forEach(pid=>{
+      if(pid===hostId){ result[pid]=[]; return; }
+      const current=[...((existingHands&&existingHands[pid])||[])];
+      while(current.length<7){ current.push(deck.shift()||''); }
+      result[pid]=current;
+    });
+    return result;
+  }
+
+  function syncPlayersOrder(){
+    const players=game.players||{};
+    const activeIds=orderedPlayerIds(players).filter(id=>players[id].active!==false);
+    const current=Array.isArray(game.playersOrder)?game.playersOrder:[];
+    const merged=[...new Set([...current.filter(id=>activeIds.includes(id)), ...activeIds])];
+    if(JSON.stringify(merged)!==JSON.stringify(current)) orderRef().set(merged);
+  }
+
+  function ensureHostValidity(){
+    const order=activeOrder();
+    const current=game.state.currentHostPid;
+    if(!order.length) return;
+    if(!current || !order.includes(current)){
+      const next=order[0];
+      const name=game.players[next]?.name||'—';
+      if(local.isCreator) stateRef().update({ currentHostPid:next, currentHostName:name });
+    }
+  }
+
+  function maybeAutoStart(){
+    if(!local.isCreator) return;
+    if(game.state.status!==STATUS.LOBBY) return;
+    if(activeOrder().length>=MIN_PLAYERS){ advanceRound(); }
+  }
+
+  function buildHandHint(status){
+    if(game.state.currentHostPid===local.playerId) return status===STATUS.COLLECT ? 'Вы ведущий — ожидайте ответы и выберите победителя.' : 'Вы управляете ходом игры.';
+    if(status===STATUS.LOBBY) return 'Ожидаем старт раунда.';
+    if(status===STATUS.RESULT) return 'Раунд завершён, ждём новую чёрную карту.';
+    if(local.hasSubmitted) return 'Ответ отправлен, ждём остальных.';
+    if(local.selectedIndex==null) return 'Выберите одну карту и подтвердите.';
+    return 'Нажмите «Подтвердить», чтобы отправить выбранную карту.';
+  }
+
+  function renderState(){
+    const status=game.state.status||STATUS.LOBBY;
+    if(local.roomId){ enterGameUI(); }
+    $('#blackText').innerHTML=escapeHtml(game.state.blackCard||'—');
+    $('#roleChip').hidden = status===STATUS.LOBBY;
+    $('#roleChip').textContent = game.state.currentHostPid===local.playerId ? 'Вы ведущий' : 'Вы игрок';
+    $('#timerChip').hidden = status!==STATUS.COLLECT;
+    $('#progressChip').hidden = status!==STATUS.COLLECT;
+    $('#resultBlock').style.display = status===STATUS.RESULT ? 'block' : 'none';
+    $('#winnerLine').innerHTML = game.state.lastWinnerName ? `${escapeHtml(game.state.lastWinnerName)} получает очко за ${fillBlack(game.state.blackCard||'', game.state.lastAnswer||'')}` : 'В этом раунде не было победителя.';
+    $('#resultHint').textContent = game.state.currentHostPid===local.playerId ? 'Запустите следующий раунд.' : 'Ждём текущего ведущего.';
+    const hostText = status===STATUS.LOBBY ? 'Ожидаем игроков.' : status===STATUS.COLLECT ? `Ведущий: ${escapeHtml(game.state.currentHostName||'—')}` : 'Раунд завершён.';
+    $('#hostSummary').textContent = hostText;
+    $('#handHint').textContent = buildHandHint(status);
+    updateProgressChip();
+  }
+
+  function renderPlayers(){
+    const list=$('#playersList'); if(!list) return;
+    list.innerHTML='';
+    const players=game.players||{};
+    const ordered=orderedPlayerIds(players);
+    ordered.forEach(id=>{
+      const data=players[id];
+      const row=document.createElement('div');
+      row.style.display='flex';
+      row.style.alignItems='center';
+      row.style.justifyContent='space-between';
+      row.style.padding='8px 0';
+      const tags=[];
+      if(data.isCreator) tags.push('модератор');
+      if(id===game.state.currentHostPid) tags.push('ведущий');
+      if(data.active===false) tags.push('offline');
+      row.innerHTML=`<div>${escapeHtml(data.name||'Безымянный')}${tags.length?` <span class="small muted">(${tags.join(', ')})</span>`:''}</div><div class="chip">${data.score||0}</div>`;
+      list.appendChild(row);
+    });
+    if(!ordered.length){ list.innerHTML='<div class="muted small">Пока никого нет.</div>'; }
   }
 
   function renderHand(hand){
-    const box=$('#handCards'); box.innerHTML='';
-    hand.forEach((txt,i)=>{
-      const btn=document.createElement('button'); btn.className='card'; btn.style.textAlign='left'; btn.textContent=txt;
-      btn.onclick=()=> submitCard(txt, i);
-      box.appendChild(btn);
+    const container=$('#handCards'); if(!container) return;
+    container.innerHTML='';
+    const disabled = game.state.currentHostPid===local.playerId || game.state.status!==STATUS.COLLECT;
+    hand.forEach((text,idx)=>{
+      const btn=document.createElement('button');
+      btn.type='button';
+      btn.className='answer-card'+(disabled?' disabled':' selectable');
+      btn.dataset.index=idx;
+      btn.innerHTML=`<div style="font-size:18px;line-height:1.5;">${escapeHtml(text)}</div>`;
+      if(!disabled){
+        btn.onclick=()=>selectCard(idx,text,btn);
+        if(idx===local.selectedIndex) btn.classList.add('selected');
+      }
+      container.appendChild(btn);
     });
   }
 
-  async function submitCard(text, idx){
-    const s= (await stateRef().get()).val(); if (!s || s.phase!=='hands') { toast('Ждём фазу выбора'); return; }
-    // убрать карту из руки
-    const handSnap = await perPlayerRef(local.playerId).get(); let hand=(handSnap.val()&&handSnap.val().hand)||[]; hand.splice(idx,1);
-    await perPlayerRef(local.playerId).set({ hand });
-    // добавить в submissions
-    const id = uid(); await submissionsRef().child(id).set({ playerId: local.playerId, text, t:Date.now() });
-    toast('Ответ отправлен');
+  function selectCard(idx,text,btn){
+    if(game.state.status!==STATUS.COLLECT) return;
+    if(local.hasSubmitted) return;
+    local.selectedIndex=idx;
+    local.selectedText=text;
+    $$('#handCards .answer-card').forEach(el=>el.classList.remove('selected'));
+    if(btn) btn.classList.add('selected');
+    updateHandState();
+    updateActionBar();
+  }
+
+  function updateHandState(){
+    $('#submittedCard').style.display = local.hasSubmitted && local.submittedText ? 'block':'none';
+    if(local.hasSubmitted && local.submittedText){ $('#submittedText').textContent=local.submittedText; }
   }
 
   function renderSubmissions(map){
-    const box=$('#submissions'); box.innerHTML='';
-    const items = shuffle(Object.entries(map||{}).map(([id,s])=>({id,...s})));
-    items.forEach(s=>{
-      const b=document.createElement('button'); b.className='card'; b.style.textAlign='left';
-      b.innerHTML=`<div class="muted small">Ответ</div><div class="big">${fillBlack(game.state.blackCard||'', s.text)}</div>`;
-      b.onclick=()=> local.isHost && game.state.phase==='judge' ? pickWinner(s.playerId, s.text) : null;
-      box.appendChild(b);
+    game.submissions=map||{};
+    const entries=Object.entries(game.submissions);
+    const received=entries.length;
+    const expected=expectedSubmissions();
+    const timerExpired = game.state.timerEndsAt && now() >= game.state.timerEndsAt;
+    const reveal = game.state.status===STATUS.RESULT || (game.state.status===STATUS.COLLECT && (timerExpired || (expected>0 && received>=expected)));
+    const list=$('#submissionsList');
+    list.innerHTML='';
+    const hint=$('#submissionsHint');
+    if(!entries.length){ hint.textContent = game.state.status===STATUS.COLLECT ? 'Карты появятся после отправки игроками.' : 'На столе нет ответов.'; return; }
+    if(!reveal){ hint.textContent='Ответы скрыты до завершения сбора.'; return; }
+    hint.textContent = game.state.status===STATUS.COLLECT ? 'Выберите победителя.' : 'Ведущий объявил результат.';
+    const prevOrder=Array.isArray(game.submissionsOrder)?game.submissionsOrder.filter(id=>game.submissions[id]):[];
+    if(prevOrder.length!==entries.length){ game.submissionsOrder=shuffle(entries.map(([id])=>id)); }
+    const order=game.submissionsOrder;
+    order.forEach(id=>{
+      const item=game.submissions[id]; if(!item) return;
+      const btn=document.createElement('button');
+      btn.type='button';
+      btn.className='answer-card';
+      btn.innerHTML=`<div class="muted small">Ответ</div><div style="margin-top:8px;font-size:18px;line-height:1.5;">${fillBlack(game.state.blackCard||'', item.text)}</div>`;
+      if(game.state.status===STATUS.COLLECT && game.state.currentHostPid===local.playerId){
+        btn.classList.add('selectable');
+        btn.onclick=()=>eventsRef().push({ type:'pickWinner', submissionId:id, t:now() });
+      } else {
+        btn.disabled=true;
+      }
+      list.appendChild(btn);
     });
+    updateProgressChip();
   }
 
-  // ===== Ведущий: старт/раунды/победитель =====
-  function maybeAutoStart(players){
-    try{
-      if (!local.isHost) return;
-      if ((game.state && game.state.phase)!=='lobby') return;
-      const count = Object.keys(players||{}).length;
-      if (count >= 2) { startGameHost(); }
-    } catch(e){ console.warn('autoStart skipped', e); }
+  function updateProgressChip(){
+    const chip=$('#progressChip'); if(!chip) return;
+    if(game.state.status!==STATUS.COLLECT){ chip.hidden=true; return; }
+    const expected=expectedSubmissions();
+    const received=Object.keys(game.submissions||{}).length;
+    chip.textContent=`${received}/${expected} отправили`;
+    chip.hidden=false;
+    chip.classList.toggle('danger', expected>0 && received<expected && game.state.timerEndsAt && game.state.timerEndsAt-now()<15000);
   }
 
-  async function startGameHost(){
-    if (!local.isHost) return toast('Только ведущий может стартовать');
-    if (playersCount < 2) return toast('Нужно минимум 2 игрока');
-    // подготовка: назначить судью 0, выдать карты всем, чёрную карту
-    game.state.round=1; game.state.phase='hands'; game.state.roundsTotal=10; game.state.judgeIndex=0;
-    const playersSnap = await playersRef().get(); const players = playersSnap.val()||{}; const ids = orderedPlayerIds(players);
-    // руки уже выданы при регистрации; убедимся, что у всех по 7
-    for(const pid of ids){ const handSnap = await perPlayerRef(pid).get(); let hand=(handSnap.val()&&handSnap.val().hand)||[]; while(hand.length<7) hand.push(drawWhite()); await perPlayerRef(pid).set({ hand }); }
-    const judgeId = ids[0] || null; const judgeName = judgeId ? players[judgeId].name : '—';
-    const black = drawBlack();
-    await stateRef().set({ ...game.state, judgeId, judgeName, blackCard:black, sfwOnly: $('#sfwOnly').checked });
-    await setJudgeFlags(ids, judgeId);
-    await submissionsRef().remove();
-    await db.ref(`rooms/${local.roomId}/deck`).set({ black: game.deck.black, white: game.deck.white, discardBlack: game.deck.discardBlack, discardWhite: game.deck.discardWhite });
+  function updateActionBar(){
+    const bar=$('#actionBar'); if(!bar) return;
+    const isHost=game.state.currentHostPid===local.playerId;
+    const collecting=game.state.status===STATUS.COLLECT;
+    if(!collecting || isHost){ bar.classList.add('hidden'); return; }
+    bar.classList.remove('hidden');
+    if(local.hasSubmitted){ $('#actionHint').textContent='Карта отправлена. Ждём остальных.'; $('#btnConfirm').disabled=true; }
+    else if(local.selectedIndex==null){ $('#actionHint').textContent='Выберите карту из руки, чтобы подтвердить.'; $('#btnConfirm').disabled=true; }
+    else { $('#actionHint').textContent='Готово! Подтвердите отправку выбранной карты.'; $('#btnConfirm').disabled=false; }
   }
 
-  async function toJudgePhaseHost(){ if(!local.isHost) return; await stateRef().update({ phase:'judge' }); }
-
-  async function pickWinner(playerId, answer){
-    if (!local.isHost) return;
-    // +1 очко игроку
-    const pRef = playersRef().child(playerId); const pSnap = await pRef.get(); const p=pSnap.val()||{}; await pRef.update({ score:(p.score||0)+1 });
-    await stateRef().update({ phase:'winner', lastWinnerName: p.name, lastAnswer: answer });
-    $('#winnerLine').innerHTML = `${escapeHtml(p.name||'—')} получает очко за: ${fillBlack(game.state.blackCard||'', answer)}`;
+  function startTimerTick(){
+    clearInterval(local.timerInterval);
+    if(game.state.status!==STATUS.COLLECT || !game.state.timerEndsAt){ $('#timerChip').hidden=true; return; }
+    $('#timerChip').hidden=false;
+    const update=()=>{
+      const seconds=Math.max(0, Math.ceil((game.state.timerEndsAt - now())/1000));
+      $('#timerChip').textContent=`⏱ ${seconds}s`;
+      if(seconds<=0){ clearInterval(local.timerInterval); if(!local.autoPickFired){ local.autoPickFired=true; eventsRef().push({ type:'autoPick', submissionId:null, t:now() }); } }
+    };
+    update();
+    local.timerInterval=setInterval(update,1000);
+    local.autoPickFired=false;
   }
 
-  async function nextRoundHost(){
-    if (!local.isHost) return; const sSnap = await stateRef().get(); const s = sSnap.val(); if (!s) return;
-    if (s.round >= s.roundsTotal) { toast('Игра окончена'); return; }
-    const players = (await playersRef().get()).val()||{}; const ids = orderedPlayerIds(players);
-    const judgeIdx = (ids.indexOf(s.judgeId)+1) % ids.length; const judgeId = ids[judgeIdx]; const judgeName = players[judgeId].name;
-    // новая чёрная, очистить submissions, добрать по 1 карте всем
-    for(const pid of ids){ const handSnap = await perPlayerRef(pid).get(); let hand=(handSnap.val()&&handSnap.val().hand)||[]; while(hand.length<7) hand.push(drawWhite()); await perPlayerRef(pid).set({ hand }); }
-    await submissionsRef().remove();
-    const black = drawBlack();
-    await stateRef().set({ ...s, round: s.round+1, judgeId, judgeName, blackCard:black, phase:'hands' });
-    await setJudgeFlags(ids, judgeId);
+  async function submitCard(){
+    if(game.state.status!==STATUS.COLLECT){ showError('Сейчас нельзя отправить карту.'); return; }
+    if(game.state.currentHostPid===local.playerId){ showError('Ведущий не отправляет карты.'); return; }
+    if(local.hasSubmitted){ showError('Карта уже отправлена.'); return; }
+    if(local.selectedIndex==null){ showError('Сначала выберите карту.'); return; }
+    const hand=[...local.activeHand];
+    const text=hand[local.selectedIndex];
+    if(!text){ showError('Карта не найдена.'); return; }
+    hand.splice(local.selectedIndex,1);
+    await perPlayerRef(local.playerId).set({ hand, submitted:true, lastText:text });
+    const id=uid();
+    await submissionsRef().child(id).set({ playerId:local.playerId, text, createdAt:now() });
+    local.hasSubmitted=true;
+    local.selectedIndex=null;
+    local.selectedText='';
+    local.submittedText=text;
+    updateHandState();
+    updateActionBar();
+    toast('Ответ отправлен');
   }
 
-  // ===== Тесты (локальные для чистых функций) =====
-  const tests=[]; function test(name,fn){tests.push({name,fn});} function expect(cond,msg){ if(!cond) throw new Error(msg||'assert failed'); }
-  async function runTests(){
-    const out=[]; for(const t of tests){ try{ await t.fn(); out.push({name:t.name,ok:true}); }catch(e){ out.push({name:t.name,ok:false,err:e.message}); } }
-    const lines = out.map(r=> `${r.ok?'✅':'❌'} ${r.name}${r.ok?'':` — ${r.err}`}`).join('\n'); $('#testsOutput').textContent=lines||'Нет тестов'; $('#dlgTests').showModal(); console.table(out);
-  }
-  // существующие тесты (не меняем)
-  test('ensureMinimumDeck(): >=120/500',()=>{ const base={black:[],white:[]}; ensureMinimumDeck(base); expect(base.black.length>=120,'black<120'); expect(base.white.length>=500,'white<500'); });
-  test('fillBlack() placeholder',()=>{ const s=fillBlack('A ____ B','X'); expect(/<b>X<\/b>/.test(s),'no replace'); });
-  // новые юнит-тесты
-  test('fillBlack() no placeholder path',()=>{ const s=fillBlack('Привет','мир'); expect(/Привет\s—\s<b>мир<\/b>/.test(s),'no dash concat'); });
-  test('escapeHtml() double quote',()=>{ const s=escapeHtml('"'); expect(s==='&quot;','not &quot;'); });
-  test('escapeHtml() complex',()=>{ const s=escapeHtml('<tag> & "\'"'); expect(s.includes('&lt;tag&gt;') && s.includes('&amp;') && s.includes('&quot;') && s.includes('&#39;'),'escape failed'); });
-  test('ensureMinimumDeck() idempotent-ish',()=>{ const base={black:["Q"],white:["W"]}; ensureMinimumDeck(base); const b1=base.black.length,w1=base.white.length; ensureMinimumDeck(base); expect(base.black.length>=b1 && base.white.length>=w1,'not growing to min'); });
-  
-  // ===== Обработчики =====
-  $('#btnHow').onclick=()=> $('#dlgRules').showModal();
-  $('#btnDeck').onclick=()=> $('#dlgDeck').showModal();
-  $('#btnSaveDeck').onclick=()=>{ try{ const j=JSON.parse($('#deckJson').value); localStorage.setItem(STORAGE_KEY, JSON.stringify(j)); toast('Колода сохранена'); if(local.isHost) loadDeckLocal(); }catch(e){ alert('Ошибка JSON: '+e.message);} };
-  $('#btnResetDeck').onclick=()=>{ localStorage.removeItem(STORAGE_KEY); if(local.isHost) loadDeckLocal(); $('#deckJson').value=JSON.stringify(DEMO_DECK,null,2); toast('Сбросили к демо'); };
-  $('#btnExport').onclick=()=>{ const blob=new Blob([$('#deckJson').value],{type:'application/json'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='deck.json'; a.click(); };
-  $('#btnImport').onclick=async()=>{ const inp=document.createElement('input'); inp.type='file'; inp.accept='application/json'; inp.onchange=async()=>{ const f=inp.files[0]; if(!f) return; $('#deckJson').value=await f.text(); }; inp.click(); };
-  $('#btnTests').onclick=runTests;
-  $('#btnNew').onclick=()=> location.href = location.origin + location.pathname;
-  $('#btnCreate').onclick=async()=>{ await createRoom(); };
-  $('#btnJoin').onclick=async()=>{ const id=($('#roomInput').value||'').trim(); if(!id) return toast('Введите ID комнаты'); await joinRoom(id); };
-  $('#btnCopy').onclick=()=>{ navigator.clipboard.writeText($('#shareLink').value); toast('Ссылка скопирована'); };
-  $('#btnToJudge').onclick = toJudgePhaseHost;
-  $('#nextRound').onclick=nextRoundHost;
-
-  function updateShareLink(){
-    const url = new URL(location.href); url.searchParams.set('room', local.roomId); $('#shareLink').value=url.toString(); $('#shareRow').style.display='flex'; history.replaceState(null,'',url);
+  async function nextRound(){
+    if(game.state.currentHostPid!==local.playerId){ showError('Следующий раунд запускает ведущий.'); return; }
+    await eventsRef().push({ type:'nextRound', t:now() });
   }
 
-  // ===== Автоподключение по ?room= =====
-  async function autoJoinFromURL(){
-    const url = new URL(location.href); const room=url.searchParams.get('room');
-    if(room){ $('#roomInput').value=room; await joinRoom(room); }
+  function toggleMenu(){ $('#menuSheet').classList.toggle('hidden'); }
+
+  function setupUI(){
+    const params=new URLSearchParams(location.search);
+    const room=params.get('room');
+    if(room){
+      local.roomId=room.toUpperCase();
+      local.isCreator=false;
+      $('#createRoomId').value=room.toUpperCase();
+      showScreen('screenJoin');
+      subscribeRoom();
+    } else {
+      $('#createRoomId').value=(Math.random().toString(36).slice(2,8)).toUpperCase();
+      showScreen('screenCreate');
+    }
+    const savedName=localStorage.getItem('playerName');
+    if(savedName){ $('#createName').value=savedName; $('#joinName').value=savedName; }
   }
 
-  // ===== Инициализация =====
-  function init(){
-    $('#playerName').value = localStorage.getItem('playerName') || '';
-    $('#deckJson').value = JSON.stringify(DEMO_DECK, null, 2);
-    const room = new URL(location.href).searchParams.get('room'); if (room){ $('#roomInput').value=room; $('#shareRow').style.display='flex'; $('#shareLink').value=location.href; }
-    if (firebaseInitError){ updateConnStatus(false, 'Ошибка инициализации: '+firebaseInitError.message); }
+  function renderOnStateChange(){ renderState(); renderHand(local.activeHand); updateActionBar(); }
+
+  function syncUIHandlers(){
+    $('#btnCreateRoom').onclick=createRoom;
+    $('#btnJoinRoom').onclick=joinRoom;
+    $('#btnCopyLink').onclick=()=>copyToClipboard($('#shareLink').value||'');
+    $('#btnConfirm').onclick=submitCard;
+    $('#btnNextRound').onclick=nextRound;
+    $('#menuBtn').onclick=toggleMenu;
+    document.addEventListener('click',e=>{ if(!$('#menuSheet').classList.contains('hidden')){ const sheet=$('#menuSheet'); if(e.target.id==='menuBtn' || sheet.contains(e.target)) return; sheet.classList.add('hidden'); } });
+    $('#menuRules').onclick=()=>{ $('#menuSheet').classList.add('hidden'); $('#dlgRules').showModal(); };
+    $('#menuDeck').onclick=()=>{ $('#menuSheet').classList.add('hidden'); $('#dlgDeck').showModal(); };
+    $('#menuTests').onclick=()=>{ $('#menuSheet').classList.add('hidden'); runTests(); };
+    $('#menuCheck').onclick=async()=>{ $('#menuSheet').classList.add('hidden'); await testDbConnection(); toast('Проверка: '+lastConnMsg); };
+    $('#menuNew').onclick=()=>{ location.href=location.origin+location.pathname; };
+    $('#btnSaveDeck').onclick=()=>{ try{ const json=JSON.parse($('#deckJson').value||'{}'); ensureMinimumDeck(json); localStorage.setItem(STORAGE_KEY, JSON.stringify(json)); if(local.isCreator) loadDeckLocal(); toast('Колода сохранена'); }catch(e){ showError('Ошибка JSON: '+e.message); } };
+    $('#btnResetDeck').onclick=()=>{ localStorage.removeItem(STORAGE_KEY); loadDeckLocal(); toast('Колода сброшена'); };
+    $('#btnExportDeck').onclick=()=>{ const blob=new Blob([$('#deckJson').value||''],{type:'application/json'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='deck.json'; a.click(); setTimeout(()=>URL.revokeObjectURL(url),500); };
+    $('#btnImportDeck').onclick=()=>{ const input=document.createElement('input'); input.type='file'; input.accept='application/json'; input.onchange=async()=>{ const file=input.files?.[0]; if(!file) return; const text=await file.text(); $('#deckJson').value=text; }; input.click(); };
   }
-  function updateConnStatus(ok,msg){ const el=$('#connStatus'); if(!el) return; el.textContent='Статус: ' + (ok?'подключено':'ошибка'); el.title=msg||''; el.style.background= ok ? 'var(--accent-2)' : 'var(--chip)'; }
-  $('#btnCheck').onclick = async ()=>{ await testDbConnection(); toast('Проверка: '+ lastConnMsg); };
-  init(); autoJoinFromURL(); setTimeout(()=>testDbConnection(), 300);
+
+  function start(){
+    setupUI();
+    syncUIHandlers();
+    if(firebaseInitError){ updateConnStatus(false,'Ошибка инициализации: '+firebaseInitError.message); }
+    setTimeout(()=>testDbConnection(),400);
+    if(local.roomId && !local.isCreator){ subscribeRoom(); }
+    renderOnStateChange();
+  }
+
+  const tests=[];
+  const test=(name,fn)=>tests.push({name,fn});
+  const expect=(cond,msg)=>{ if(!cond) throw new Error(msg||'assert failed'); };
+
+  test('orderedPlayerIds() сортирует по joinedAt',()=>{
+    const players={a:{joinedAt:3},b:{joinedAt:1},c:{joinedAt:2}};
+    expect(JSON.stringify(orderedPlayerIds(players))===JSON.stringify(['b','c','a']),'order mismatch');
+  });
+
+  test('одна отправка за раунд',()=>{
+    const state={submitted:false};
+    const mark=s=>{ if(s.submitted) throw new Error('повторный submit'); s.submitted=true; return s; };
+    mark(state);
+    let failed=false; try{ mark(state); }catch(e){ failed=true; }
+    expect(failed,'submit прошёл второй раз');
+  });
+
+  test('topUpHand() добивает до 7',()=>{
+    const hand=topUpHand(['a'],7);
+    expect(hand.length===7,'hand size');
+  });
+
+  test('ротация ведущего по playersOrder',()=>{
+    const order=['p1','p2','p3'];
+    expect(nextHostId(order,null)==='p1','first host не p1');
+    expect(nextHostId(order,'p1')==='p2','p1 -> p2');
+    expect(nextHostId(order,'p3')==='p1','p3 -> p1');
+  });
+
+  test('раздача до 7 белых всем не-ведущим',()=>{
+    const order=['host','p1','p2'];
+    const hands={ host:['x'], p1:['a','b','c'], p2:[] };
+    const fill=simulateHandFill(order,'host',hands,['d','e','f','g','h','i','j','k','l']);
+    expect(fill.host.length===0,'host должен остаться без карт');
+    expect(fill.p1.length===7,'p1 добирает до 7');
+    expect(fill.p2.length===7,'p2 добирает до 7');
+  });
+
+  test('таймер авто-выбор победителя',()=>{
+    const submissions={ a:{text:'X'}, b:{text:'Y'} };
+    const pick=randomSubmissionKey(submissions,()=>0.6);
+    expect(pick==='b','ожидали выбор b');
+    const none=randomSubmissionKey({},()=>0.1);
+    expect(none===null,'при пустом наборе null');
+  });
+
+  window.runTests=async()=>{
+    const results=[];
+    for(const t of tests){
+      try{ await t.fn(); results.push({name:t.name, ok:true}); }
+      catch(e){ results.push({name:t.name, ok:false, err:e.message}); }
+    }
+    $('#testsOutput').textContent=results.map(r=>`${r.ok?'✅':'❌'} ${r.name}${r.ok?'':` — ${r.err}`}`).join('\n');
+    $('#dlgTests').showModal();
+  };
+
+  document.addEventListener('DOMContentLoaded',()=>{
+    start();
+  });
   </script>
+  <!-- Что изменено -->
+  <!-- 1. Переписан стартовый поток: отдельные экраны создания и входа, бургер-меню и мобильный UI. -->
+  <!-- 2. Реализована автоматическая раздача, ротация ведущего, таймер и анонимные ответы через Firebase. -->
+  <!-- 3. Добавлены проверки имени, новая колода, подсказки и юнит-тесты ключевых сценариев. -->
+  <!-- TODO -->
+  <!-- - Вынести таймер на сервер и добавить анти-спам для событий. -->
+  <!-- - Расширить анимации открытия ответов и финального экрана. -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- trigger the lobby auto-start routine whenever the playersOrder queue updates
- ensure newly joined players immediately start the first round once minimum players are present

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de28e11e08832684218c7129055d98